### PR TITLE
Adding allocation tests

### DIFF
--- a/pkg/intern/bytes_interner_bench_test.go
+++ b/pkg/intern/bytes_interner_bench_test.go
@@ -1,0 +1,71 @@
+package intern
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkBytesInterner_NoneInterned(b *testing.B) {
+	interner := NewBytesInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	bytes := make([][]byte, b.N)
+	for i := range bytes {
+		bytes[i] = []byte(strconv.Itoa(i))
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, bytesVal := range bytes {
+		interner.Get(bytesVal)
+	}
+}
+
+func BenchmarkBytesInterner_AllInterned(b *testing.B) {
+	interner := NewBytesInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	bytes := make([][]byte, b.N)
+	for i := range bytes {
+		bytes[i] = []byte(strconv.Itoa(i))
+	}
+
+	for _, bytesVal := range bytes {
+		interner.Get(bytesVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for _, bytesVal := range bytes {
+		interner.Get(bytesVal)
+	}
+}
+
+// Benchmark getting already interned values, but limit the size of the set of interned values.
+//
+// This simulates the behaviour when the interner is used on a smallish fixed set of common values.
+func BenchmarkBytesInterner_AllInterned10K(b *testing.B) {
+	interner := NewBytesInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	bytes := make([][]byte, 10_000)
+	for i := range bytes {
+		bytes[i] = []byte(strconv.Itoa(i))
+	}
+
+	for _, bytesVal := range bytes {
+		interner.Get(bytesVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for {
+		for _, bytesVal := range bytes {
+			interner.Get(bytesVal)
+			count++
+			if count >= b.N {
+				return
+			}
+		}
+	}
+}

--- a/pkg/intern/bytes_interner_test.go
+++ b/pkg/intern/bytes_interner_test.go
@@ -277,9 +277,9 @@ func TestBytesInterner_Complex(t *testing.T) {
 	}
 }
 
-// This benchmark is intended to demonstrate that getting string values for
-// []byte that have already been interned does not allocate
-func BenchmarkBytesInterner(b *testing.B) {
+// Assert that getting a string, where the value has already been interned,
+// does not allocate
+func TestBytesInterner_NoAllocations(t *testing.T) {
 	interner := NewBytesInterner(Config{MaxLen: 0, MaxBytes: 0})
 
 	bytes := make([][]byte, 10_000)
@@ -291,17 +291,12 @@ func BenchmarkBytesInterner(b *testing.B) {
 		interner.Get(bytesVal)
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	count := 0
-	for {
+	avgAllocs := testing.AllocsPerRun(100, func() {
 		for _, bytesVal := range bytes {
 			interner.Get(bytesVal)
-			count++
-			if count >= b.N {
-				return
-			}
 		}
-	}
+	})
+	// getting strings for bytes which have already been interned does not
+	// allocate
+	assert.Equal(t, 0.0, avgAllocs)
 }

--- a/pkg/intern/float64_interner_bench_test.go
+++ b/pkg/intern/float64_interner_bench_test.go
@@ -1,0 +1,70 @@
+package intern
+
+import (
+	"testing"
+)
+
+func BenchmarkFloat64Interner_NoneInterned(b *testing.B) {
+	interner := NewFloat64Interner(Config{MaxLen: 0, MaxBytes: 0}, 'f', -1, 64)
+
+	floats := make([]float64, b.N)
+	for i := range floats {
+		floats[i] = float64(i) + 0.123
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, floatVal := range floats {
+		interner.Get(floatVal)
+	}
+}
+
+func BenchmarkFloat64Interner_AllInterned(b *testing.B) {
+	interner := NewFloat64Interner(Config{MaxLen: 0, MaxBytes: 0}, 'f', -1, 64)
+
+	floats := make([]float64, b.N)
+	for i := range floats {
+		floats[i] = float64(i) + 0.123
+	}
+
+	for _, floatVal := range floats {
+		interner.Get(floatVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for _, floatVal := range floats {
+		interner.Get(floatVal)
+	}
+}
+
+// Benchmark getting already interned values, but limit the size of the set of interned values.
+//
+// This simulates the behaviour when the interner is used on a smallish fixed set of common values.
+func BenchmarkFloat64Interner_AllInterned10K(b *testing.B) {
+	interner := NewFloat64Interner(Config{MaxLen: 0, MaxBytes: 0}, 'f', -1, 64)
+
+	floats := make([]float64, 10_000)
+	for i := range floats {
+		floats[i] = float64(i) + 0.123
+	}
+
+	for _, floatVal := range floats {
+		interner.Get(floatVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for {
+		for _, floatVal := range floats {
+			interner.Get(floatVal)
+			count++
+			if count >= b.N {
+				return
+			}
+		}
+	}
+}

--- a/pkg/intern/float64_interner_test.go
+++ b/pkg/intern/float64_interner_test.go
@@ -172,9 +172,9 @@ func TestFloat64Interner_Complex(t *testing.T) {
 	}
 }
 
-// This benchmark is intended to demonstrate that getting string values for
-// floats that have already been interned does not allocate
-func BenchmarkFloat64Interner(b *testing.B) {
+// Assert that getting a string, where the value has already been interned,
+// does not allocate
+func TestFloat64Interner_NoAllocations(t *testing.T) {
 	interner := NewFloat64Interner(Config{MaxLen: 0, MaxBytes: 0}, 'f', -1, 64)
 
 	floats := make([]float64, 10_000)
@@ -186,17 +186,12 @@ func BenchmarkFloat64Interner(b *testing.B) {
 		interner.Get(floatVal)
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	count := 0
-	for {
+	avgAllocs := testing.AllocsPerRun(100, func() {
 		for _, floatVal := range floats {
 			interner.Get(floatVal)
-			count++
-			if count >= b.N {
-				return
-			}
 		}
-	}
+	})
+	// getting strings for floats which have already been interned does not
+	// allocate
+	assert.Equal(t, 0.0, avgAllocs)
 }

--- a/pkg/intern/int64_interner_bench_test.go
+++ b/pkg/intern/int64_interner_bench_test.go
@@ -1,0 +1,70 @@
+package intern
+
+import (
+	"testing"
+)
+
+func BenchmarkInt64Interner_NoneInterned(b *testing.B) {
+	interner := NewInt64Interner(Config{MaxLen: 0, MaxBytes: 0}, 10)
+
+	ints := make([]int64, b.N)
+	for i := range ints {
+		ints[i] = int64(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, intVal := range ints {
+		interner.Get(intVal)
+	}
+}
+
+func BenchmarkInt64Interner_AllInterned(b *testing.B) {
+	interner := NewInt64Interner(Config{MaxLen: 0, MaxBytes: 0}, 10)
+
+	ints := make([]int64, b.N)
+	for i := range ints {
+		ints[i] = int64(i)
+	}
+
+	for _, intVal := range ints {
+		interner.Get(intVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for _, intVal := range ints {
+		interner.Get(intVal)
+	}
+}
+
+// Benchmark getting already interned values, but limit the size of the set of interned values.
+//
+// This simulates the behaviour when the interner is used on a smallish fixed set of common values.
+func BenchmarkInt64Interner_AllInterned10K(b *testing.B) {
+	interner := NewInt64Interner(Config{MaxLen: 0, MaxBytes: 0}, 10)
+
+	ints := make([]int64, 10_000)
+	for i := range ints {
+		ints[i] = int64(i)
+	}
+
+	for _, intVal := range ints {
+		interner.Get(intVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for {
+		for _, intVal := range ints {
+			interner.Get(intVal)
+			count++
+			if count >= b.N {
+				return
+			}
+		}
+	}
+}

--- a/pkg/intern/int64_interner_test.go
+++ b/pkg/intern/int64_interner_test.go
@@ -172,9 +172,9 @@ func TestInt64Interner_Complex(t *testing.T) {
 	}
 }
 
-// This benchmark is intended to demonstrate that getting string values for
-// integers that have already been interned does not allocate
-func BenchmarkInt64Interner(b *testing.B) {
+// Assert that getting a string, where the value has already been interned,
+// does not allocate
+func TestInt64Interner_NoAllocations(t *testing.T) {
 	interner := NewInt64Interner(Config{MaxLen: 0, MaxBytes: 0}, 10)
 
 	ints := make([]int64, 10_000)
@@ -186,17 +186,12 @@ func BenchmarkInt64Interner(b *testing.B) {
 		interner.Get(intVal)
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	count := 0
-	for {
+	avgAllocs := testing.AllocsPerRun(100, func() {
 		for _, intVal := range ints {
 			interner.Get(intVal)
-			count++
-			if count >= b.N {
-				return
-			}
 		}
-	}
+	})
+	// getting strings for ints which have already been interned does not
+	// allocate
+	assert.Equal(t, 0.0, avgAllocs)
 }

--- a/pkg/intern/string_interner_bench_test.go
+++ b/pkg/intern/string_interner_bench_test.go
@@ -1,0 +1,71 @@
+package intern
+
+import (
+	"strconv"
+	"testing"
+)
+
+func BenchmarkStringInterner_NoneInterned(b *testing.B) {
+	interner := NewStringInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	strings := make([]string, b.N)
+	for i := range strings {
+		strings[i] = strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, stringVal := range strings {
+		interner.Get(stringVal)
+	}
+}
+
+func BenchmarkStringInterner_AllInterned(b *testing.B) {
+	interner := NewStringInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	strings := make([]string, b.N)
+	for i := range strings {
+		strings[i] = strconv.Itoa(i)
+	}
+
+	for _, stringVal := range strings {
+		interner.Get(stringVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for _, stringVal := range strings {
+		interner.Get(stringVal)
+	}
+}
+
+// Benchmark getting already interned values, but limit the size of the set of interned values.
+//
+// This simulates the behaviour when the interner is used on a smallish fixed set of common values.
+func BenchmarkStringInterner_AllInterned10K(b *testing.B) {
+	interner := NewStringInterner(Config{MaxLen: 0, MaxBytes: 0})
+
+	strings := make([]string, 10_000)
+	for i := range strings {
+		strings[i] = strconv.Itoa(i)
+	}
+
+	for _, stringVal := range strings {
+		interner.Get(stringVal)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for {
+		for _, stringVal := range strings {
+			interner.Get(stringVal)
+			count++
+			if count >= b.N {
+				return
+			}
+		}
+	}
+}

--- a/pkg/intern/string_interner_test.go
+++ b/pkg/intern/string_interner_test.go
@@ -277,9 +277,9 @@ func TestStringInterner_Complex(t *testing.T) {
 	}
 }
 
-// This benchmark is intended to demonstrate that getting string values for
-// strings that have already been interned does not allocate
-func BenchmarkStringInterner(b *testing.B) {
+// Assert that getting a string, where the value has already been interned,
+// does not allocate
+func TestStringInterner_NoAllocations(t *testing.T) {
 	interner := NewStringInterner(Config{MaxLen: 0, MaxBytes: 0})
 
 	strings := make([]string, 10_000)
@@ -291,17 +291,12 @@ func BenchmarkStringInterner(b *testing.B) {
 		interner.Get(stringVal)
 	}
 
-	b.ReportAllocs()
-	b.ResetTimer()
-
-	count := 0
-	for {
+	avgAllocs := testing.AllocsPerRun(100, func() {
 		for _, stringVal := range strings {
 			interner.Get(stringVal)
-			count++
-			if count >= b.N {
-				return
-			}
 		}
-	}
+	})
+	// getting strings for string which have already been interned does not
+	// allocate
+	assert.Equal(t, 0.0, avgAllocs)
 }

--- a/pkg/intern/time_interner_bench_test.go
+++ b/pkg/intern/time_interner_bench_test.go
@@ -1,0 +1,74 @@
+package intern
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkTimeInterner_NoneInterned(b *testing.B) {
+	interner := NewTimeInterner(Config{MaxLen: 0, MaxBytes: 0}, time.RFC1123)
+
+	timestamps := make([]time.Time, b.N)
+	now := time.Now()
+	for i := range timestamps {
+		timestamps[i] = now.Add(time.Nanosecond)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for _, timestamp := range timestamps {
+		interner.Get(timestamp)
+	}
+}
+
+func BenchmarkTimeInterner_AllInterned(b *testing.B) {
+	interner := NewTimeInterner(Config{MaxLen: 0, MaxBytes: 0}, time.RFC1123)
+
+	timestamps := make([]time.Time, b.N)
+	now := time.Now()
+	for i := range timestamps {
+		timestamps[i] = now.Add(time.Nanosecond)
+	}
+
+	for _, timestamp := range timestamps {
+		interner.Get(timestamp)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for _, timestamp := range timestamps {
+		interner.Get(timestamp)
+	}
+}
+
+// Benchmark getting already interned values, but limit the size of the set of interned values.
+//
+// This simulates the behaviour when the interner is used on a smallish fixed set of common values.
+func BenchmarkTimeInterner_AllInterned10K(b *testing.B) {
+	interner := NewTimeInterner(Config{MaxLen: 0, MaxBytes: 0}, time.RFC1123)
+
+	timestamps := make([]time.Time, 10_000)
+	now := time.Now()
+	for i := range timestamps {
+		timestamps[i] = now.Add(time.Nanosecond)
+	}
+
+	for _, timestamp := range timestamps {
+		interner.Get(timestamp)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	count := 0
+	for {
+		for _, timestamp := range timestamps {
+			interner.Get(timestamp)
+			count++
+			if count >= b.N {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
These unit tests directly assert that calling Get(...) on an interner with an already interned string does not allocate at all.

We also create some benchmarks.