### PR TITLE
Assert offheap.Store.Destroy() no error in tests

### DIFF
--- a/offheap/internal/pointerstore/pointer_store_test.go
+++ b/offheap/internal/pointerstore/pointer_store_test.go
@@ -60,7 +60,9 @@ func TestSlabIntegrity(t *testing.T) {
 		t.Run(fmt.Sprintf("Test allocation integrity for %d", objectSize), func(t *testing.T) {
 			conf := NewAllocConfigBySize(objectSize, 1<<16)
 			store := New(conf)
-			defer store.Destroy()
+			defer func() {
+				assert.NoError(t, store.Destroy())
+			}()
 
 			// Force 3 slabs to be created for this object size
 			// Test that the allocations for each slab are correct

--- a/offheap/object_reference_multitype_test.go
+++ b/offheap/object_reference_multitype_test.go
@@ -287,7 +287,9 @@ func TestIndexForType(t *testing.T) {
 // times.
 func TestSizedStats(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	testSizedStats[SizedArrayZero](t, os)
 	testSizedStats[SizedArray1](t, os)
@@ -337,7 +339,9 @@ func testSizedStats[T any](t *testing.T, os *Store) {
 // to store all objects.
 func Test_Object_NewModifyGet_Multitype(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[SizedArray0](os)
 	// perform a number of allocations which will force the creation of extra slabs
@@ -363,7 +367,9 @@ func Test_Object_NewModifyGet_Multitype(t *testing.T) {
 // to store all objects.
 func Test_Object_GetModifyGet_Multitype(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[SizedArray0](os)
 	// perform a number of allocations which will force the creation of extra slabs

--- a/offheap/object_reference_race_test.go
+++ b/offheap/object_reference_race_test.go
@@ -19,7 +19,9 @@ const goroutines = 100
 // This test should be run with -race
 func TestSeparateGoroutines_Race(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	barrier := sync.WaitGroup{}
 	barrier.Add(1)
@@ -63,7 +65,9 @@ func TestAllocAndShare_Race(t *testing.T) {
 	sharedChannel := make(chan RefObject[MutableStruct], goroutines*allocsPerGoroutine)
 
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	barrier := sync.WaitGroup{}
 	barrier.Add(1)
@@ -120,7 +124,9 @@ func TestAllocAndShare_Multitype_Race(t *testing.T) {
 	sharedChannel := make(chan *MultitypeAllocation, goroutines*allocsPerGoroutine)
 
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	barrier := sync.WaitGroup{}
 	barrier.Add(1)

--- a/offheap/object_reference_test.go
+++ b/offheap/object_reference_test.go
@@ -20,7 +20,9 @@ type MutableStruct struct {
 // to store all objects.
 func Test_Object_NewModifyGet(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[MutableStruct](os)
 
@@ -52,7 +54,9 @@ func Test_Object_NewModifyGet(t *testing.T) {
 // to store all objects.
 func Test_Object_GetModifyGet(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[MutableStruct](os)
 
@@ -86,7 +90,9 @@ func Test_Object_GetModifyGet(t *testing.T) {
 // the freed object ObjectStore panics
 func Test_Object_NewFreeGet_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	FreeObject(os, r)
@@ -98,7 +104,9 @@ func Test_Object_NewFreeGet_Panic(t *testing.T) {
 // the freed object ObjectStore panics
 func Test_Object_NewFreeFree_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	FreeObject(os, r)
@@ -109,7 +117,9 @@ func Test_Object_NewFreeFree_Panic(t *testing.T) {
 // Demonstrate that when we double free a re-allocated object we panic
 func Test_Object_NewFreeAllocFree_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	FreeObject(os, r)
@@ -124,7 +134,9 @@ func Test_Object_NewFreeAllocFree_Panic(t *testing.T) {
 // eventually overflow and old values will be repeated.
 func Test_Object_NewFree256ReallocFree_NoPanic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	oldGen := r.ref.Gen()
@@ -145,7 +157,9 @@ func Test_Object_NewFree256ReallocFree_NoPanic(t *testing.T) {
 // Demonstrate that when we get a re-allocated object we panic
 func Test_Object_NewFreeAllocGet_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	FreeObject(os, r)
@@ -160,7 +174,9 @@ func Test_Object_NewFreeAllocGet_Panic(t *testing.T) {
 // eventually overflow and old values will be repeated.
 func Test_Object_NewFree256ReallocGet_NoPanic(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocObject[MutableStruct](os)
 	oldGen := r.ref.Gen()
@@ -182,7 +198,9 @@ func Test_Object_NewFree256ReallocGet_NoPanic(t *testing.T) {
 // then allocate that same number again, we re-use the freed objects
 func Test_Object_NewFreeNew_ReusesOldObjects(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[MutableStruct](os)
 
@@ -250,7 +268,9 @@ func Test_Object_NewFreeNew_ReusesOldObjects(t *testing.T) {
 // independently allocated references would all point to the same slot.
 func Test_Object_FreeThenAllocTwice(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	// Allocate an object
 	r1 := AllocObject[MutableStruct](os)
@@ -285,7 +305,9 @@ func Test_Object_FreeThenAllocTwice(t *testing.T) {
 
 func Test_Object_CheckGenericTypeForPointersInAlloc(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	// If generic type contains pointers, Alloc will panic
 	assert.Panics(t, func() { AllocObject[*int](os) })
@@ -329,7 +351,9 @@ func Test_Object_CannotAllocateVeryBigStruct(t *testing.T) {
 // edge-case bugs for all eternity.
 func Test_Object_ZeroSizedType_FullSlab(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	allocConf := ConfForType[SizedArrayZero](os)
 

--- a/offheap/slice_reference_test.go
+++ b/offheap/slice_reference_test.go
@@ -33,7 +33,7 @@ var testSizeRanges = []int{
 func Test_Slice_AllocateModifyAndGet(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Allocate it
@@ -63,7 +63,7 @@ func Test_Slice_AllocateModifyAndGet(t *testing.T) {
 func Test_Slice_AllocateModifyAndGet_ManySizes(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	for _, length := range testSizeRanges {
@@ -101,7 +101,7 @@ func Test_Slice_AllocateModifyAndGet_ManySizes(t *testing.T) {
 func Test_Slice_NewFreeGet_Panic(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Allocate and free a slice value
@@ -117,7 +117,7 @@ func Test_Slice_NewFreeGet_Panic(t *testing.T) {
 func Test_Slice_NewFreeFree_Panic(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Allocate and free a slice value
@@ -131,7 +131,9 @@ func Test_Slice_NewFreeFree_Panic(t *testing.T) {
 // Demonstrate that when we double free a re-allocated slice we still panic.
 func Test_Slice_NewFreeAllocFree_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocSlice[MutableStruct](os, 10, 10)
 	FreeSlice(os, r)
@@ -144,7 +146,9 @@ func Test_Slice_NewFreeAllocFree_Panic(t *testing.T) {
 // Demonstrate that when we call Value() on a re-allocated RefSlice we still panic
 func Test_Slice_NewFreeAllocGet_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	r := AllocSlice[MutableStruct](os, 10, 10)
 	FreeSlice(os, r)
@@ -161,7 +165,9 @@ func Test_Slice_NewFreeAllocGet_Panic(t *testing.T) {
 // times.
 func Test_Slice_SizedStats(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	for _, capacity := range []int{
 		0,
@@ -208,7 +214,9 @@ func Test_Slice_SizedStats(t *testing.T) {
 
 func Test_Slice_Append(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	for _, length := range testSizeRanges {
 		for _, extraCapacity := range testSizeRanges {
@@ -296,7 +304,9 @@ func doSliceAppendTest[T any](t *testing.T, os *Store, length, extraCapacity int
 
 func Test_Slice_AppendSlice(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	for _, length := range testSizeRanges {
 		for _, extraCapacity := range testSizeRanges {
@@ -391,7 +401,9 @@ func doSliceAppendSliceTest[T any](t *testing.T, os *Store, length, extraCapacit
 
 func Test_Slice_ConcatSlices(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	for _, testCase := range []struct {
 		slices [][]int64

--- a/offheap/string_examples_test.go
+++ b/offheap/string_examples_test.go
@@ -13,7 +13,7 @@ import (
 // Calling AllocStringFromString allocates a string and returns a RefString
 // which acts like a conventional pointer through which you can retrieve the
 // allocated string via RefString.Value()
-func ExampleAllocFromString() {
+func ExampleAllocStringFromString() {
 	var store *offheap.Store = offheap.New()
 
 	var ref offheap.RefString = offheap.AllocStringFromString(store, "allocated")

--- a/offheap/string_reference_test.go
+++ b/offheap/string_reference_test.go
@@ -17,7 +17,7 @@ import (
 func Test_String_AllocateAndGet_Simple(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Create string
@@ -46,7 +46,7 @@ func Test_String_AllocateAndGet_Simple(t *testing.T) {
 func Test_String_AllocateAndGet(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	rsm := testutil.NewRandomStringMaker()
@@ -80,7 +80,7 @@ func Test_String_AllocateAndGet(t *testing.T) {
 func Test_String_NewFreeGet_Panic(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Allocate and free a string value
@@ -98,7 +98,7 @@ func Test_String_NewFreeGet_Panic(t *testing.T) {
 func Test_String_NewFreeFree_Panic(t *testing.T) {
 	ss := NewSized(1 << 8)
 	defer func() {
-		ss.Destroy()
+		assert.NoError(t, ss.Destroy())
 	}()
 
 	// Allocate and free a string value
@@ -113,7 +113,9 @@ func Test_String_NewFreeFree_Panic(t *testing.T) {
 // Demonstrate that when we double free a re-allocated string we still panic.
 func Test_String_NewFreeAllocFree_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	value := "test string"
 	r := AllocStringFromString(os, value)
@@ -127,7 +129,9 @@ func Test_String_NewFreeAllocFree_Panic(t *testing.T) {
 // Demonstrate that when we call Value() on a re-allocated RefStr we still panic
 func Test_String_NewFreeAllocGet_Panic(t *testing.T) {
 	os := NewSized(1 << 8)
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	value := "test string"
 	r := AllocStringFromString(os, value)
@@ -145,7 +149,9 @@ func Test_String_NewFreeAllocGet_Panic(t *testing.T) {
 // times.
 func Test_String_SizedStats(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	rsm := testutil.NewRandomStringMaker()
 
@@ -196,7 +202,9 @@ func Test_String_SizedStats(t *testing.T) {
 
 func Test_String_AppendString(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	rsm := testutil.NewRandomStringMaker()
 
@@ -220,7 +228,9 @@ func Test_String_AppendString(t *testing.T) {
 
 func Test_String_ConcatStrings(t *testing.T) {
 	os := New()
-	defer os.Destroy()
+	defer func() {
+		assert.NoError(t, os.Destroy())
+	}()
 
 	for _, testCase := range []struct {
 		strs []string


### PR DESCRIPTION
Previously we were just calling this method and assuming it worked. This is a large step towards allowing us to use golangci-lint in the build.