### PR TITLE
RefPointer, and all other Reference types, are only 64 bits wide

### DIFF
--- a/offheap/internal/pointerstore/free_list.go
+++ b/offheap/internal/pointerstore/free_list.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Francis Michael Stephens. All rights reserved.  Use of this
+// source code is governed by an MIT license that can be found in the LICENSE
+// file.
+
+package pointerstore
+
+type freeStack struct {
+	free []RefPointer
+}
+
+func (s *freeStack) push(r RefPointer) {
+	s.free = append(s.free, r)
+}
+
+func (s *freeStack) pop() (r RefPointer, ok bool) {
+	l := len(s.free)
+	if l == 0 {
+		return RefPointer{}, false
+	}
+
+	r = s.free[l-1]
+	s.free = s.free[:l-1]
+	return r, true
+}

--- a/offheap/internal/pointerstore/free_list_test.go
+++ b/offheap/internal/pointerstore/free_list_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Francis Michael Stephens. All rights reserved.  Use of this
+// source code is governed by an MIT license that can be found in the LICENSE
+// file.
+
+package pointerstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFreeStack_Empty(t *testing.T) {
+	s := freeStack{}
+	r, ok := s.pop()
+	assert.True(t, r.IsNil())
+	assert.False(t, ok)
+}
+
+// Push 3 references onto the stack. Pop them off in reverse order
+func TestFreeStack_PushPop(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 32*8)
+	objects, metadatas := MmapSlab(allocConfig)
+
+	s := freeStack{}
+
+	r1Push := NewReference(objects[0], metadatas[0])
+	r2Push := NewReference(objects[1], metadatas[1])
+	r3Push := NewReference(objects[2], metadatas[2])
+
+	s.push(r1Push)
+	s.push(r2Push)
+	s.push(r3Push)
+
+	r3Pop, ok3 := s.pop()
+	assert.Equal(t, r3Push, r3Pop)
+	assert.True(t, ok3)
+
+	r2Pop, ok2 := s.pop()
+	assert.Equal(t, r2Push, r2Pop)
+	assert.True(t, ok2)
+
+	r1Pop, ok1 := s.pop()
+	assert.Equal(t, r1Push, r1Pop)
+	assert.True(t, ok1)
+
+	r0Pop, ok0 := s.pop()
+	assert.True(t, r0Pop.IsNil())
+	assert.False(t, ok0)
+}
+
+// Push three references off, pop two, push two more. Pop remaining references.
+func TestFreeStack_PushPopComplex(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 32*8)
+	objects, metadatas := MmapSlab(allocConfig)
+
+	s := freeStack{}
+
+	r1Push := NewReference(objects[0], metadatas[0])
+	r2Push := NewReference(objects[1], metadatas[1])
+	r3Push := NewReference(objects[2], metadatas[2])
+	r4Push := NewReference(objects[3], metadatas[3])
+	r5Push := NewReference(objects[4], metadatas[4])
+
+	s.push(r1Push)
+	s.push(r2Push)
+	s.push(r3Push)
+
+	r3Pop, ok3 := s.pop()
+	assert.Equal(t, r3Push, r3Pop)
+	assert.True(t, ok3)
+
+	r2Pop, ok2 := s.pop()
+	assert.Equal(t, r2Push, r2Pop)
+	assert.True(t, ok2)
+
+	s.push(r4Push)
+	s.push(r5Push)
+
+	r5Pop, ok5 := s.pop()
+	assert.Equal(t, r5Push, r5Pop)
+	assert.True(t, ok5)
+
+	r4Pop, ok4 := s.pop()
+	assert.Equal(t, r4Push, r4Pop)
+	assert.True(t, ok4)
+
+	r1Pop, ok1 := s.pop()
+	assert.Equal(t, r1Push, r1Pop)
+	assert.True(t, ok1)
+
+	r0Pop, ok0 := s.pop()
+	assert.True(t, r0Pop.IsNil())
+	assert.False(t, ok0)
+}

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -42,32 +42,15 @@ func (m *metadata) setNotFree() {
 	m.dataAddressAndGen = m.dataAddressAndGen.withNotFree()
 }
 
-// Check that the metadata for a reference agrees with the generation tag and
-// the data address.  Failure results in a panic.
+// Check that the metadata for a reference agrees with the generation tag.
+// Failure results in a panic.
 //
 // Please note, we never set the is-free bit in the taggedAddress of the
 // RefPointer. So we don't expect them to match and don't check that here.
 //
 //gcassert:noescape
 func (m *metadata) checkReference(r *RefPointer) {
-	if m.dataAddressAndGen != r.address {
-		mGen := m.gen()
-		rGen := r.Gen()
-		mAddress := m.dataAddressAndGen.address()
-		rAddress := r.address.address()
-
-		genMismatchMessage := fmt.Sprintf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen())
-		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.address.address())
-
-		switch {
-		case mGen != rGen && mAddress != rAddress:
-			panic(fmt.Errorf(genMismatchMessage + " and " + addressMismatchMessage))
-
-		case mGen != rGen:
-			panic(fmt.Errorf(genMismatchMessage))
-
-		case mAddress != rAddress:
-			panic(fmt.Errorf(addressMismatchMessage))
-		}
+	if m.gen() != r.Gen() {
+		panic(fmt.Errorf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen()))
 	}
 }

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -22,8 +22,9 @@ func (m *metadata) gen() uint8 {
 }
 
 //gcassert:noescape
-func (m *metadata) setGen(gen uint8) {
-	m.dataAddressAndGen = m.dataAddressAndGen.withGen(gen)
+func (m *metadata) incGen() uint8 {
+	m.dataAddressAndGen = m.dataAddressAndGen.withIncGen()
+	return m.dataAddressAndGen.gen()
 }
 
 //gcassert:noescape

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -42,8 +42,11 @@ func (m *metadata) setNotFree() {
 	m.dataAddressAndGen = m.dataAddressAndGen.withNotFree()
 }
 
-// Check that the metadata for a reference agrees with the generation tag and the data address.
-// Failure results in a panic.
+// Check that the metadata for a reference agrees with the generation tag and
+// the data address.  Failure results in a panic.
+//
+// Please note, we never set the is-free bit in the taggedAddress of the
+// RefPointer. So we don't expect them to match and don't check that here.
 //
 //gcassert:noescape
 func (m *metadata) checkReference(r *RefPointer) {

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Francis Michael Stephens. All rights reserved.  Use of this
+// source code is governed by an MIT license that can be found in the LICENSE
+// file.
+
+package pointerstore
+
+import "fmt"
+
+// If the object's metadata has a non-nil nextFree pointer then the object is
+// currently free. Object's which have never been allocated are implicitly
+// free, but have a nil nextFree.
+//
+// A RefPointer smuggles a generation tag. Only references with the same gen
+// value can access/free objects they point to. This is a best-effort safety
+// check to try to catch use-after-free type errors.
+type metadata struct {
+	nextFree          RefPointer
+	dataAddressAndGen taggedAddress
+}
+
+//gcassert:noescape
+func (m *metadata) gen() uint8 {
+	return m.dataAddressAndGen.gen()
+}
+
+//gcassert:noescape
+func (m *metadata) setGen(gen uint8) {
+	m.dataAddressAndGen = m.dataAddressAndGen.withGen(gen)
+}
+
+// Check that the metadata for a reference agrees with the generation tag and the data address.
+// Failure results in a panic.
+//
+//gcassert:noescape
+func (m *metadata) checkReference(r *RefPointer) {
+	if m.dataAddressAndGen != r.dataAddressAndGen {
+		mGen := m.gen()
+		rGen := r.Gen()
+		mAddress := m.dataAddressAndGen.address()
+		rAddress := r.dataAddressAndGen.address()
+
+		genMismatchMessage := fmt.Sprintf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen())
+		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.dataAddressAndGen.address())
+
+		switch {
+		case mGen != rGen && mAddress != rAddress:
+			panic(fmt.Errorf(genMismatchMessage + " and " + addressMismatchMessage))
+
+		case mGen != rGen:
+			panic(fmt.Errorf(genMismatchMessage))
+
+		case mAddress != rAddress:
+			panic(fmt.Errorf(addressMismatchMessage))
+		}
+	}
+}

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -14,8 +14,8 @@ import "fmt"
 // value can access/free objects they point to. This is a best-effort safety
 // check to try to catch use-after-free type errors.
 type metadata struct {
-	nextFree          RefPointer
 	dataAddressAndGen taggedAddress
+	isFree            bool
 }
 
 //gcassert:noescape

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -4,8 +4,6 @@
 
 package pointerstore
 
-import "fmt"
-
 // If the object's metadata has a non-nil nextFree pointer then the object is
 // currently free. Object's which have never been allocated are implicitly
 // free, but have a nil nextFree.
@@ -40,17 +38,4 @@ func (m *metadata) setFree() {
 //gcassert:noescape
 func (m *metadata) setNotFree() {
 	m.dataAddressAndGen = m.dataAddressAndGen.withNotFree()
-}
-
-// Check that the metadata for a reference agrees with the generation tag.
-// Failure results in a panic.
-//
-// Please note, we never set the is-free bit in the taggedAddress of the
-// RefPointer. So we don't expect them to match and don't check that here.
-//
-//gcassert:noescape
-func (m *metadata) checkReference(r *RefPointer) {
-	if m.gen() != r.Gen() {
-		panic(fmt.Errorf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen()))
-	}
 }

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -4,13 +4,14 @@
 
 package pointerstore
 
-// If the object's metadata has a non-nil nextFree pointer then the object is
-// currently free. Object's which have never been allocated are implicitly
-// free, but have a nil nextFree.
-//
 // A RefPointer smuggles a generation tag. Only references with the same gen
 // value can access/free objects they point to. This is a best-effort safety
 // check to try to catch use-after-free type errors.
+//
+// Metadata smuggles a generation tag and an is-free tag into its
+// taggedAddress. When accessing the data from a RefPointer we check that the
+// metadata indicates the object is not free and that the RefPointer's
+// generation matches that of the metadat.
 type metadata struct {
 	dataAddressAndGen taggedAddress
 }

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -15,7 +15,6 @@ import "fmt"
 // check to try to catch use-after-free type errors.
 type metadata struct {
 	dataAddressAndGen taggedAddress
-	isFree            bool
 }
 
 //gcassert:noescape
@@ -26,6 +25,21 @@ func (m *metadata) gen() uint8 {
 //gcassert:noescape
 func (m *metadata) setGen(gen uint8) {
 	m.dataAddressAndGen = m.dataAddressAndGen.withGen(gen)
+}
+
+//gcassert:noescape
+func (m *metadata) isFree() bool {
+	return m.dataAddressAndGen.isFree()
+}
+
+//gcassert:noescape
+func (m *metadata) setFree() {
+	m.dataAddressAndGen = m.dataAddressAndGen.withFree()
+}
+
+//gcassert:noescape
+func (m *metadata) setNotFree() {
+	m.dataAddressAndGen = m.dataAddressAndGen.withNotFree()
 }
 
 // Check that the metadata for a reference agrees with the generation tag and the data address.

--- a/offheap/internal/pointerstore/metadata.go
+++ b/offheap/internal/pointerstore/metadata.go
@@ -50,14 +50,14 @@ func (m *metadata) setNotFree() {
 //
 //gcassert:noescape
 func (m *metadata) checkReference(r *RefPointer) {
-	if m.dataAddressAndGen != r.dataAddressAndGen {
+	if m.dataAddressAndGen != r.address {
 		mGen := m.gen()
 		rGen := r.Gen()
 		mAddress := m.dataAddressAndGen.address()
-		rAddress := r.dataAddressAndGen.address()
+		rAddress := r.address.address()
 
 		genMismatchMessage := fmt.Sprintf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen())
-		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.dataAddressAndGen.address())
+		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.address.address())
 
 		switch {
 		case mGen != rGen && mAddress != rAddress:

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -57,15 +57,10 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 
 //gcassert:noescape
 func (r *RefPointer) free() {
+	// Check that this reference can access the allocation to free it
+	r.accessibleActiveAddress()
+
 	meta := r.metadata()
-
-	if meta.isFree() {
-		// NB: The odd-looking *r here actually prevents an allocation.
-		// Fuller explanation found in DataPtr()
-		panic(fmt.Errorf("attempted to Free freed allocation %v", *r))
-	}
-
-	meta.checkReference(r)
 
 	// Mark the object as free
 	meta.setFree()
@@ -90,6 +85,7 @@ func (r *RefPointer) allocFromFree() {
 
 	// This object is now allocated and is no long free
 	meta.setNotFree()
+
 	// Update this reference so it's generatation tag matches the metadata
 	r.setGen(meta.gen())
 }
@@ -101,7 +97,7 @@ func (r *RefPointer) allocFromFree() {
 //gcassert:noescape
 func (r *RefPointer) Realloc() RefPointer {
 	// Test that this reference is actually allowed to access the allocation
-	r.dataAddress()
+	r.accessibleActiveAddress()
 
 	newRef := *r
 
@@ -123,14 +119,14 @@ func (r *RefPointer) IsNil() bool {
 
 //gcassert:noescape
 func (r *RefPointer) DataPtr() uintptr {
-	return r.dataAddress().address()
+	return r.accessibleActiveAddress().address()
 }
 
 // Convenient method to retrieve raw data of an allocation
 //
 //gcassert:noescape
 func (r *RefPointer) Bytes(size int) []byte {
-	return r.dataAddress().bytes(size)
+	return r.accessibleActiveAddress().bytes(size)
 }
 
 // Calling this method
@@ -140,7 +136,7 @@ func (r *RefPointer) Bytes(size int) []byte {
 // 3: Returns the taggedAddress pointing to the actual data
 //
 //gcassert:noescape
-func (r *RefPointer) dataAddress() taggedAddress {
+func (r *RefPointer) accessibleActiveAddress() taggedAddress {
 	meta := r.metadata()
 
 	if meta.isFree() {
@@ -151,10 +147,12 @@ func (r *RefPointer) dataAddress() taggedAddress {
 		// call, but if we don't take a copy of r in the fmt call, then
 		// every call will allocate regardless of whether the method
 		// panics or not
-		panic(fmt.Errorf("attempt to get freed allocation %v", *r))
+		panic(fmt.Errorf("attempt to access freed allocation %v", *r))
 	}
 
-	meta.checkReference(r)
+	if meta.gen() != r.Gen() {
+		panic(fmt.Errorf("generation mismatch between metadata (%d) and reference (%d)", meta.gen(), r.Gen()))
+	}
 
 	return meta.dataAddressAndGen
 }

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -52,7 +52,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	meta := r.metadata()
 	meta.dataAddressAndGen = r.dataAddressAndGen
 	// The value defaults to false, but we write it here for readability
-	meta.isFree = false
+	meta.setNotFree()
 
 	return r
 }
@@ -61,7 +61,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 func (r *RefPointer) free() {
 	meta := r.metadata()
 
-	if meta.isFree {
+	if meta.isFree() {
 		// NB: The odd-looking *r here actually prevents an allocation.
 		// Fuller explanation found in DataPtr()
 		panic(fmt.Errorf("attempted to Free freed allocation %v", *r))
@@ -70,7 +70,7 @@ func (r *RefPointer) free() {
 	meta.checkReference(r)
 
 	// Mark the object as free
-	meta.isFree = true
+	meta.setFree()
 
 	// Increment the generation for the allocation and set that generation in
 	// the Metadata and Reference
@@ -87,7 +87,7 @@ func (r *RefPointer) allocFromFree() {
 	meta := r.metadata()
 
 	// This object is now allocated and is no long free
-	meta.isFree = false
+	meta.setNotFree()
 	// Update this reference so it's generatation tag matches the metadata
 	r.setGen(meta.gen())
 }
@@ -118,7 +118,7 @@ func (r *RefPointer) IsNil() bool {
 func (r *RefPointer) DataPtr() uintptr {
 	meta := r.metadata()
 
-	if meta.isFree {
+	if meta.isFree() {
 		// NB: We make a copy of r here - otherwise the compiler
 		// believes that r itself escapes to the heap (not strictly
 		// wrong) and will allocate it to the heap, even if this path

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -15,17 +15,6 @@ import (
 // The generation must be masked out to get a usable pointer value. The object
 // pointed to must have the same generation value in order to access/free that
 // object.
-//
-// Because the Refpointer struct is two words (on 64 bit systems) in size, all
-// method receivers are pointers to avoid copying two words in method calls.
-// However, the RefPointer is _always_ used as a value. This means that having
-// a pointer receiver could potentially cause the RefPointer to be allocated if
-// its receiver escapes to the heap (according to escape analysis). We assert
-// that all methods do not allow their receiver variable to escape to the heap.
-//
-// This is all very nice and good, but the idea that avoiding copying two words
-// is a meaningful improvement are speculative and haven't been tested. This
-// would be a good target for future performance testing.
 type RefPointer struct {
 	address taggedAddress
 }
@@ -55,8 +44,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	return r
 }
 
-//gcassert:noescape
-func (r *RefPointer) free() {
+func (r RefPointer) free() {
 	// Check that this reference can access the allocation to free it
 	r.accessibleActiveAddress()
 
@@ -74,13 +62,11 @@ func (r *RefPointer) free() {
 
 // Sets the RefPointer's metadata to not-free and creates a new RefPointer with
 // the correct generation tag.
-//
-//gcassert:noescape
-func (r *RefPointer) allocFromFree() RefPointer {
+func (r RefPointer) allocFromFree() RefPointer {
 	meta := r.metadata()
 
 	if !meta.isFree() {
-		panic(fmt.Errorf("attempt to alloc-from-free active allocation %v", *r))
+		panic(fmt.Errorf("attempt to alloc-from-free active allocation %v", r))
 	}
 
 	// This object is now allocated and is no long free
@@ -93,9 +79,7 @@ func (r *RefPointer) allocFromFree() RefPointer {
 // This method re-allocates the memory location. When this method returns r
 // will no longer be a valid reference.  The reference returned _will_ be a
 // valid reference to the same location.
-//
-//gcassert:noescape
-func (r *RefPointer) Realloc() RefPointer {
+func (r RefPointer) Realloc() RefPointer {
 	// Test that this reference is actually allowed to access the allocation
 	r.accessibleActiveAddress()
 
@@ -109,20 +93,16 @@ func (r *RefPointer) Realloc() RefPointer {
 	return r.withGen(gen)
 }
 
-//gcassert:noescape
-func (r *RefPointer) DataPtr() uintptr {
+func (r RefPointer) DataPtr() uintptr {
 	return r.accessibleActiveAddress().address()
 }
 
 // Convenient method to retrieve raw data of an allocation
-//
-//gcassert:noescape
-func (r *RefPointer) Bytes(size int) []byte {
+func (r RefPointer) Bytes(size int) []byte {
 	return r.accessibleActiveAddress().bytes(size)
 }
 
-//gcassert:noescape
-func (r *RefPointer) IsNil() bool {
+func (r RefPointer) IsNil() bool {
 	return r.address.isNil()
 }
 
@@ -131,20 +111,11 @@ func (r *RefPointer) IsNil() bool {
 // 1: looks up the metadata for this reference
 // 2: Verifies that the reference is _allowed_ to access this data
 // 3: Returns the taggedAddress pointing to the actual data
-//
-//gcassert:noescape
-func (r *RefPointer) accessibleActiveAddress() taggedAddress {
+func (r RefPointer) accessibleActiveAddress() taggedAddress {
 	meta := r.metadata()
 
 	if meta.isFree() {
-		// NB: We make a copy of r here - otherwise the compiler
-		// believes that r itself escapes to the heap (not strictly
-		// wrong) and will allocate it to the heap, even if this path
-		// is not taken. This panic path _does_ allocate due to the fmt
-		// call, but if we don't take a copy of r in the fmt call, then
-		// every call will allocate regardless of whether the method
-		// panics or not
-		panic(fmt.Errorf("attempt to access freed allocation %v", *r))
+		panic(fmt.Errorf("attempt to access freed allocation %v", r))
 	}
 
 	if meta.gen() != r.Gen() {
@@ -154,28 +125,19 @@ func (r *RefPointer) accessibleActiveAddress() taggedAddress {
 	return meta.dataAddressAndGen
 }
 
-//gcassert:noescape
-func (r *RefPointer) metaPtr() uintptr {
-	return r.metaAddress().address()
-}
-
-//gcassert:noescape
-func (r *RefPointer) metadata() *metadata {
+func (r RefPointer) metadata() *metadata {
 	return (*metadata)(unsafe.Pointer(r.metaAddress().address()))
 }
 
-//gcassert:noescape
-func (r *RefPointer) metaAddress() taggedAddress {
+func (r RefPointer) metaAddress() taggedAddress {
 	return r.address
 }
 
-//gcassert:noescape
-func (r *RefPointer) Gen() uint8 {
+func (r RefPointer) Gen() uint8 {
 	return r.address.gen()
 }
 
-//gcassert:noescape
-func (r *RefPointer) withGen(gen uint8) RefPointer {
+func (r RefPointer) withGen(gen uint8) RefPointer {
 	return RefPointer{
 		address: r.address.withGen(gen),
 	}

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -9,10 +9,6 @@ import (
 	"unsafe"
 )
 
-const maskShift = 56 // This leaves 8 bits for the generation data
-const genMask = uint64(0xFF << maskShift)
-const pointerMask = ^genMask
-
 // The address field holds a pointer to an object, but also sneaks a generation
 // value in the top 8 bits of the dataAddress field.
 //
@@ -31,8 +27,8 @@ const pointerMask = ^genMask
 // is a meaningful improvement are speculative and haven't been tested. This
 // would be a good target for future performance testing.
 type RefPointer struct {
-	dataAddressAndGen uint64
-	metaAddress       uint64
+	dataAddressAndGen taggedAddress
+	metaAddress       taggedAddress
 }
 
 // If the object's metadata has a non-nil nextFree pointer then the object is
@@ -44,17 +40,17 @@ type RefPointer struct {
 // check to try to catch use-after-free type errors.
 type metadata struct {
 	nextFree          RefPointer
-	dataAddressAndGen uint64
+	dataAddressAndGen taggedAddress
 }
 
 //gcassert:noescape
 func (m *metadata) gen() uint8 {
-	return (uint8)((m.dataAddressAndGen & genMask) >> maskShift)
+	return m.dataAddressAndGen.gen()
 }
 
 //gcassert:noescape
 func (m *metadata) setGen(gen uint8) {
-	m.dataAddressAndGen = (m.dataAddressAndGen & pointerMask) | (uint64(gen) << maskShift)
+	m.dataAddressAndGen = m.dataAddressAndGen.withGen(gen)
 }
 
 // Check that the metadata for a reference agrees with the generation tag and the data address.
@@ -81,12 +77,8 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	}
 
 	r := RefPointer{
-		dataAddressAndGen: uint64(dataAddress),
-		metaAddress:       uint64(metaAddress),
-	}
-
-	if r.Gen() != 0 {
-		panic(fmt.Errorf("the data pointer (%d) contains a non-zero generation tag (%d)", dataAddress, r.Gen()))
+		dataAddressAndGen: newTaggedAddress(dataAddress),
+		metaAddress:       newTaggedAddress(metaAddress),
 	}
 
 	// Set the dataAddressAndGen in this reference's metadata.
@@ -143,7 +135,7 @@ func (r *RefPointer) Free(oldFree RefPointer) {
 
 //gcassert:noescape
 func (r *RefPointer) IsNil() bool {
-	return r.metadataPtr() == 0
+	return r.dataAddressAndGen.isNil()
 }
 
 //gcassert:noescape
@@ -163,20 +155,19 @@ func (r *RefPointer) DataPtr() uintptr {
 
 	meta.checkReference(r)
 
-	return (uintptr)(r.dataAddressAndGen & pointerMask)
+	return r.dataAddressAndGen.address()
 }
 
 // Convenient method to retrieve raw data of an allocation
 //
 //gcassert:noescape
 func (r *RefPointer) Bytes(size int) []byte {
-	ptr := r.DataPtr()
-	return pointerToBytes(ptr, size)
+	return r.dataAddressAndGen.bytes(size)
 }
 
 //gcassert:noescape
 func (r *RefPointer) metadataPtr() uintptr {
-	return (uintptr)(r.metaAddress & pointerMask)
+	return r.metaAddress.address()
 }
 
 //gcassert:noescape
@@ -186,12 +177,12 @@ func (r *RefPointer) metadata() *metadata {
 
 //gcassert:noescape
 func (r *RefPointer) Gen() uint8 {
-	return (uint8)((r.dataAddressAndGen & genMask) >> maskShift)
+	return r.dataAddressAndGen.gen()
 }
 
 //gcassert:noescape
 func (r *RefPointer) setGen(gen uint8) {
-	r.dataAddressAndGen = (r.dataAddressAndGen & pointerMask) | (uint64(gen) << maskShift)
+	r.dataAddressAndGen = r.dataAddressAndGen.withGen(gen)
 }
 
 // This method re-allocates the memory location. When this method returns r

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -116,6 +116,17 @@ func (r *RefPointer) IsNil() bool {
 
 //gcassert:noescape
 func (r *RefPointer) DataPtr() uintptr {
+	return r.dataAddress().address()
+}
+
+// Convenient method to retrieve raw data of an allocation
+//
+//gcassert:noescape
+func (r *RefPointer) Bytes(size int) []byte {
+	return r.dataAddress().bytes(size)
+}
+
+func (r *RefPointer) dataAddress() taggedAddress {
 	meta := r.metadata()
 
 	if meta.isFree() {
@@ -131,14 +142,7 @@ func (r *RefPointer) DataPtr() uintptr {
 
 	meta.checkReference(r)
 
-	return r.address.address()
-}
-
-// Convenient method to retrieve raw data of an allocation
-//
-//gcassert:noescape
-func (r *RefPointer) Bytes(size int) []byte {
-	return r.address.bytes(size)
+	return r.address
 }
 
 //gcassert:noescape

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -126,11 +126,7 @@ func (r RefPointer) accessibleActiveAddress() taggedAddress {
 }
 
 func (r RefPointer) metadata() *metadata {
-	return (*metadata)(unsafe.Pointer(r.metaAddress().address()))
-}
-
-func (r RefPointer) metaAddress() taggedAddress {
-	return r.address
+	return (*metadata)(unsafe.Pointer(r.address.address()))
 }
 
 func (r RefPointer) Gen() uint8 {

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -84,6 +84,10 @@ func (r *RefPointer) free() {
 func (r *RefPointer) allocFromFree() {
 	meta := r.metadata()
 
+	if !meta.isFree() {
+		panic(fmt.Errorf("attempt to alloc-from-free active allocation %v", *r))
+	}
+
 	// This object is now allocated and is no long free
 	meta.setNotFree()
 	// Update this reference so it's generatation tag matches the metadata

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -72,11 +72,11 @@ func (r *RefPointer) free() {
 	meta.setGen(gen)
 }
 
-// NB: In the future this method should return a new RefPointer with updated
-// generation tag instead of modifying the method receiver.
+// Sets the RefPointer's metadata to not-free and creates a new RefPointer with
+// the correct generation tag.
 //
 //gcassert:noescape
-func (r *RefPointer) allocFromFree() {
+func (r *RefPointer) allocFromFree() RefPointer {
 	meta := r.metadata()
 
 	if !meta.isFree() {
@@ -86,8 +86,8 @@ func (r *RefPointer) allocFromFree() {
 	// This object is now allocated and is no long free
 	meta.setNotFree()
 
-	// Update this reference so it's generatation tag matches the metadata
-	r.setGen(meta.gen())
+	// Create new RefPointer with correct generation tag
+	return r.withGen(meta.gen())
 }
 
 // This method re-allocates the memory location. When this method returns r
@@ -99,8 +99,6 @@ func (r *RefPointer) Realloc() RefPointer {
 	// Test that this reference is actually allowed to access the allocation
 	r.accessibleActiveAddress()
 
-	newRef := *r
-
 	// Get metadata generation tag and increment it
 	meta := r.metadata()
 	gen := meta.gen()
@@ -108,13 +106,7 @@ func (r *RefPointer) Realloc() RefPointer {
 
 	// Set the new generation tag in both the metadata and reference
 	meta.setGen(gen)
-	newRef.setGen(gen)
-	return newRef
-}
-
-//gcassert:noescape
-func (r *RefPointer) IsNil() bool {
-	return r.address.isNil()
+	return r.withGen(gen)
 }
 
 //gcassert:noescape
@@ -127,6 +119,11 @@ func (r *RefPointer) DataPtr() uintptr {
 //gcassert:noescape
 func (r *RefPointer) Bytes(size int) []byte {
 	return r.accessibleActiveAddress().bytes(size)
+}
+
+//gcassert:noescape
+func (r *RefPointer) IsNil() bool {
+	return r.address.isNil()
 }
 
 // Calling this method
@@ -178,6 +175,8 @@ func (r *RefPointer) Gen() uint8 {
 }
 
 //gcassert:noescape
-func (r *RefPointer) setGen(gen uint8) {
-	r.address = r.address.withGen(gen)
+func (r *RefPointer) withGen(gen uint8) RefPointer {
+	return RefPointer{
+		address: r.address.withGen(gen),
+	}
 }

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -27,8 +27,8 @@ import (
 // is a meaningful improvement are speculative and haven't been tested. This
 // would be a good target for future performance testing.
 type RefPointer struct {
-	dataAddressAndGen taggedAddress
-	metaAddress       taggedAddress
+	address     taggedAddress
+	metaAddress taggedAddress
 }
 
 func NewReference(dataAddress, metaAddress uintptr) RefPointer {
@@ -41,8 +41,8 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	}
 
 	r := RefPointer{
-		dataAddressAndGen: newTaggedAddress(dataAddress),
-		metaAddress:       newTaggedAddress(metaAddress),
+		address:     newTaggedAddress(dataAddress),
+		metaAddress: newTaggedAddress(metaAddress),
 	}
 
 	// Set the dataAddressAndGen in this reference's metadata.
@@ -50,7 +50,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	// In one of the next steps we will use this to look up the actual data
 	// _and_ verify the generation of the reference.
 	meta := r.metadata()
-	meta.dataAddressAndGen = r.dataAddressAndGen
+	meta.dataAddressAndGen = r.address
 	// The value defaults to false, but we write it here for readability
 	meta.setNotFree()
 
@@ -111,7 +111,7 @@ func (r *RefPointer) Realloc() RefPointer {
 
 //gcassert:noescape
 func (r *RefPointer) IsNil() bool {
-	return r.dataAddressAndGen.isNil()
+	return r.address.isNil()
 }
 
 //gcassert:noescape
@@ -131,14 +131,14 @@ func (r *RefPointer) DataPtr() uintptr {
 
 	meta.checkReference(r)
 
-	return r.dataAddressAndGen.address()
+	return r.address.address()
 }
 
 // Convenient method to retrieve raw data of an allocation
 //
 //gcassert:noescape
 func (r *RefPointer) Bytes(size int) []byte {
-	return r.dataAddressAndGen.bytes(size)
+	return r.address.bytes(size)
 }
 
 //gcassert:noescape
@@ -153,10 +153,10 @@ func (r *RefPointer) metadata() *metadata {
 
 //gcassert:noescape
 func (r *RefPointer) Gen() uint8 {
-	return r.dataAddressAndGen.gen()
+	return r.address.gen()
 }
 
 //gcassert:noescape
 func (r *RefPointer) setGen(gen uint8) {
-	r.dataAddressAndGen = r.dataAddressAndGen.withGen(gen)
+	r.address = r.address.withGen(gen)
 }

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -14,7 +14,7 @@ const genMask = uint64(0xFF << maskShift)
 const pointerMask = ^genMask
 
 // The address field holds a pointer to an object, but also sneaks a generation
-// value in the top 8 bits of the metaAddress field.
+// value in the top 8 bits of the dataAddress field.
 //
 // The generation must be masked out to get a usable pointer value. The object
 // pointed to must have the same generation value in order to access/free that
@@ -159,12 +159,12 @@ func (r *RefPointer) metadata() *metadata {
 
 //gcassert:noescape
 func (r *RefPointer) Gen() uint8 {
-	return (uint8)((r.metaAddress & genMask) >> maskShift)
+	return (uint8)((r.dataAddress & genMask) >> maskShift)
 }
 
 //gcassert:noescape
 func (r *RefPointer) setGen(gen uint8) {
-	r.metaAddress = (r.metaAddress & pointerMask) | (uint64(gen) << maskShift)
+	r.dataAddress = (r.dataAddress & pointerMask) | (uint64(gen) << maskShift)
 }
 
 // This method re-allocates the memory location. When this method returns r

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -58,12 +58,10 @@ func (m *metadata) setGen(gen uint8) {
 //
 //gcassert:noescape
 func (m *metadata) checkReference(r *RefPointer) {
-	if m.gen() != r.Gen() {
-		panic(fmt.Errorf("attempt to get value (%d) using stale reference (%d)", m.gen(), r.Gen()))
-	}
-
 	if m.dataAddressAndGen != r.dataAddressAndGen {
-		panic(fmt.Errorf("attempt to get value where reference's data-address (%d) and metadata's data-address (%d) are different", r.dataAddressAndGen, m.dataAddressAndGen))
+		const hexWidth = 16
+		panic(fmt.Errorf("attempt to get value where reference's taggedAddress (%#0*X) and metadata's taggedAddress (%#0*X) are different", hexWidth, r.dataAddressAndGen, hexWidth, m.dataAddressAndGen))
+
 	}
 }
 

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -31,55 +31,6 @@ type RefPointer struct {
 	metaAddress       taggedAddress
 }
 
-// If the object's metadata has a non-nil nextFree pointer then the object is
-// currently free. Object's which have never been allocated are implicitly
-// free, but have a nil nextFree.
-//
-// An object's metadata has a gen field. Only references with the same gen
-// value can access/free objects they point to. This is a best-effort safety
-// check to try to catch use-after-free type errors.
-type metadata struct {
-	nextFree          RefPointer
-	dataAddressAndGen taggedAddress
-}
-
-//gcassert:noescape
-func (m *metadata) gen() uint8 {
-	return m.dataAddressAndGen.gen()
-}
-
-//gcassert:noescape
-func (m *metadata) setGen(gen uint8) {
-	m.dataAddressAndGen = m.dataAddressAndGen.withGen(gen)
-}
-
-// Check that the metadata for a reference agrees with the generation tag and the data address.
-// Failure results in a panic.
-//
-//gcassert:noescape
-func (m *metadata) checkReference(r *RefPointer) {
-	if m.dataAddressAndGen != r.dataAddressAndGen {
-		mGen := m.gen()
-		rGen := r.Gen()
-		mAddress := m.dataAddressAndGen.address()
-		rAddress := r.dataAddressAndGen.address()
-
-		genMismatchMessage := fmt.Sprintf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen())
-		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.dataAddressAndGen.address())
-
-		switch {
-		case mGen != rGen && mAddress != rAddress:
-			panic(fmt.Errorf(genMismatchMessage + " and " + addressMismatchMessage))
-
-		case mGen != rGen:
-			panic(fmt.Errorf(genMismatchMessage))
-
-		case mAddress != rAddress:
-			panic(fmt.Errorf(addressMismatchMessage))
-		}
-	}
-}
-
 func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	if dataAddress == (uintptr)(unsafe.Pointer(nil)) {
 		panic("cannot create new Reference with nil data pointer")

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -96,6 +96,9 @@ func (r *RefPointer) allocFromFree() {
 //
 //gcassert:noescape
 func (r *RefPointer) Realloc() RefPointer {
+	// Test that this reference is actually allowed to access the allocation
+	r.dataAddress()
+
 	newRef := *r
 
 	// Get metadata generation tag and increment it

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -31,11 +31,11 @@ type RefPointer struct {
 }
 
 func NewReference(dataAddress, metaAddress uintptr) RefPointer {
-	if dataAddress == (uintptr)(unsafe.Pointer(nil)) {
+	if dataAddress == nilPtr {
 		panic("cannot create new Reference with nil data pointer")
 	}
 
-	if metaAddress == (uintptr)(unsafe.Pointer(nil)) {
+	if metaAddress == nilPtr {
 		panic("cannot create new Reference with nil metadata pointer")
 	}
 

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -59,9 +59,24 @@ func (m *metadata) setGen(gen uint8) {
 //gcassert:noescape
 func (m *metadata) checkReference(r *RefPointer) {
 	if m.dataAddressAndGen != r.dataAddressAndGen {
-		const hexWidth = 16
-		panic(fmt.Errorf("attempt to get value where reference's taggedAddress (%#0*X) and metadata's taggedAddress (%#0*X) are different", hexWidth, r.dataAddressAndGen, hexWidth, m.dataAddressAndGen))
+		mGen := m.gen()
+		rGen := r.Gen()
+		mAddress := m.dataAddressAndGen.address()
+		rAddress := r.dataAddressAndGen.address()
 
+		genMismatchMessage := fmt.Sprintf("generation mismatch between metadata (%d) and reference (%d)", m.gen(), r.Gen())
+		addressMismatchMessage := fmt.Sprintf("address mismatch between metadata (%#0*X) and reference (%#0*X)", 14, m.dataAddressAndGen.address(), 14, r.dataAddressAndGen.address())
+
+		switch {
+		case mGen != rGen && mAddress != rAddress:
+			panic(fmt.Errorf(genMismatchMessage + " and " + addressMismatchMessage))
+
+		case mGen != rGen:
+			panic(fmt.Errorf(genMismatchMessage))
+
+		case mAddress != rAddress:
+			panic(fmt.Errorf(addressMismatchMessage))
+		}
 	}
 }
 

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -51,22 +51,18 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	// _and_ verify the generation of the reference.
 	meta := r.metadata()
 	meta.dataAddressAndGen = r.dataAddressAndGen
+	// The value defaults to false, but we write it here for readability
+	meta.isFree = false
 
 	return r
 }
 
 //gcassert:noescape
-func (r *RefPointer) AllocFromFree() (nextFree RefPointer) {
-	// Grab the nextFree reference, and nil it for this metadata
+func (r *RefPointer) allocFromFree() {
 	meta := r.metadata()
-	nextFree = meta.nextFree
-	meta.nextFree = RefPointer{}
 
-	// If the nextFree pointer points back to this Reference, then there
-	// are no more freed slots available
-	if nextFree == *r {
-		nextFree = RefPointer{}
-	}
+	// This object is now allocated and is no long free
+	meta.isFree = false
 
 	// Increment the generation for the allocation and set that generation in
 	// the Metadata and Reference
@@ -74,15 +70,13 @@ func (r *RefPointer) AllocFromFree() (nextFree RefPointer) {
 	gen++
 	meta.setGen(gen)
 	r.setGen(gen)
-
-	return nextFree
 }
 
 //gcassert:noescape
-func (r *RefPointer) Free(oldFree RefPointer) {
+func (r *RefPointer) free() {
 	meta := r.metadata()
 
-	if !meta.nextFree.IsNil() {
+	if meta.isFree {
 		// NB: The odd-looking *r here actually prevents an allocation.
 		// Fuller explanation found in DataPtr()
 		panic(fmt.Errorf("attempted to Free freed allocation %v", *r))
@@ -90,11 +84,8 @@ func (r *RefPointer) Free(oldFree RefPointer) {
 
 	meta.checkReference(r)
 
-	if oldFree.IsNil() {
-		meta.nextFree = *r
-	} else {
-		meta.nextFree = oldFree
-	}
+	// Mark the object as free
+	meta.isFree = true
 }
 
 //gcassert:noescape
@@ -106,7 +97,7 @@ func (r *RefPointer) IsNil() bool {
 func (r *RefPointer) DataPtr() uintptr {
 	meta := r.metadata()
 
-	if !meta.nextFree.IsNil() {
+	if meta.isFree {
 		// NB: We make a copy of r here - otherwise the compiler
 		// believes that r itself escapes to the heap (not strictly
 		// wrong) and will allocate it to the heap, even if this path

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -27,8 +27,7 @@ import (
 // is a meaningful improvement are speculative and haven't been tested. This
 // would be a good target for future performance testing.
 type RefPointer struct {
-	address     taggedAddress
-	metaAddress taggedAddress
+	address taggedAddress
 }
 
 func NewReference(dataAddress, metaAddress uintptr) RefPointer {
@@ -41,8 +40,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	}
 
 	r := RefPointer{
-		address:     newTaggedAddress(dataAddress),
-		metaAddress: newTaggedAddress(metaAddress),
+		address: newTaggedAddress(metaAddress),
 	}
 
 	// Set the dataAddressAndGen in this reference's metadata.
@@ -50,7 +48,7 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	// In one of the next steps we will use this to look up the actual data
 	// _and_ verify the generation of the reference.
 	meta := r.metadata()
-	meta.dataAddressAndGen = r.address
+	meta.dataAddressAndGen = newTaggedAddress(dataAddress)
 	// The value defaults to false, but we write it here for readability
 	meta.setNotFree()
 
@@ -95,6 +93,8 @@ func (r *RefPointer) allocFromFree() {
 // This method re-allocates the memory location. When this method returns r
 // will no longer be a valid reference.  The reference returned _will_ be a
 // valid reference to the same location.
+//
+//gcassert:noescape
 func (r *RefPointer) Realloc() RefPointer {
 	newRef := *r
 
@@ -126,6 +126,13 @@ func (r *RefPointer) Bytes(size int) []byte {
 	return r.dataAddress().bytes(size)
 }
 
+// Calling this method
+//
+// 1: looks up the metadata for this reference
+// 2: Verifies that the reference is _allowed_ to access this data
+// 3: Returns the taggedAddress pointing to the actual data
+//
+//gcassert:noescape
 func (r *RefPointer) dataAddress() taggedAddress {
 	meta := r.metadata()
 
@@ -142,17 +149,22 @@ func (r *RefPointer) dataAddress() taggedAddress {
 
 	meta.checkReference(r)
 
-	return r.address
+	return meta.dataAddressAndGen
 }
 
 //gcassert:noescape
-func (r *RefPointer) metadataPtr() uintptr {
-	return r.metaAddress.address()
+func (r *RefPointer) metaPtr() uintptr {
+	return r.metaAddress().address()
 }
 
 //gcassert:noescape
 func (r *RefPointer) metadata() *metadata {
-	return (*metadata)(unsafe.Pointer(r.metadataPtr()))
+	return (*metadata)(unsafe.Pointer(r.metaAddress().address()))
+}
+
+//gcassert:noescape
+func (r *RefPointer) metaAddress() taggedAddress {
+	return r.address
 }
 
 //gcassert:noescape

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -94,7 +94,7 @@ func (r RefPointer) Realloc() RefPointer {
 }
 
 func (r RefPointer) DataPtr() uintptr {
-	return r.accessibleActiveAddress().address()
+	return r.accessibleActiveAddress().pointer()
 }
 
 // Convenient method to retrieve raw data of an allocation
@@ -126,7 +126,7 @@ func (r RefPointer) accessibleActiveAddress() taggedAddress {
 }
 
 func (r RefPointer) metadata() *metadata {
-	return (*metadata)(unsafe.Pointer(r.address.address()))
+	return (*metadata)(unsafe.Pointer(r.address.pointer()))
 }
 
 func (r RefPointer) Gen() uint8 {

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -43,32 +43,56 @@ type RefPointer struct {
 // value can access/free objects they point to. This is a best-effort safety
 // check to try to catch use-after-free type errors.
 type metadata struct {
-	nextFree RefPointer
-	gen      uint8
+	nextFree          RefPointer
+	dataAddressAndGen uint64
 }
 
-func NewReference(pAddress, pMetadata uintptr) RefPointer {
-	if pAddress == (uintptr)(unsafe.Pointer(nil)) {
-		panic("cannot create new Reference with nil pointer")
+//gcassert:noescape
+func (m *metadata) gen() uint8 {
+	return (uint8)((m.dataAddressAndGen & genMask) >> maskShift)
+}
+
+//gcassert:noescape
+func (m *metadata) setGen(gen uint8) {
+	m.dataAddressAndGen = (m.dataAddressAndGen & pointerMask) | (uint64(gen) << maskShift)
+}
+
+// Check that the metadata for a reference agrees with the generation tag and the data address.
+// Failure results in a panic.
+//
+//gcassert:noescape
+func (m *metadata) checkReference(r *RefPointer) {
+	if m.gen() != r.Gen() {
+		panic(fmt.Errorf("attempt to get value (%d) using stale reference (%d)", m.gen(), r.Gen()))
 	}
 
-	address := uint64(pAddress)
-	// This sets the generation to 0 by clearing the smuggled bits
-	maskedAddress := address & pointerMask
+	if m.dataAddressAndGen != r.dataAddressAndGen {
+		panic(fmt.Errorf("attempt to get value where reference's data-address (%d) and metadata's data-address (%d) are different", r.dataAddressAndGen, m.dataAddressAndGen))
+	}
+}
 
-	// Setting the generation 0 shouldn't actually change the address
-	// If there were any 1s in the top part of the address our generation
-	// smuggling system will break this pointer. This is an unrecoverable error.
-	if address != maskedAddress {
-		panic(fmt.Errorf("the raw pointer (%d) uses more than %d bits", address, maskShift))
+func NewReference(dataAddress, metaAddress uintptr) RefPointer {
+	if dataAddress == (uintptr)(unsafe.Pointer(nil)) {
+		panic("cannot create new Reference with nil data pointer")
 	}
 
-	// NB: The gen on a brand new Reference is always 0
-	// So we don't set it
-	return RefPointer{
-		dataAddressAndGen: maskedAddress,
-		metaAddress:       uint64(pMetadata),
+	r := RefPointer{
+		dataAddressAndGen: uint64(dataAddress),
+		metaAddress:       uint64(metaAddress),
 	}
+
+	if r.Gen() != 0 {
+		panic(fmt.Errorf("the data pointer (%d) contains a non-zero generation tag (%d)", dataAddress, r.Gen()))
+	}
+
+	// Set the dataAddressAndGen in this reference's metadata.
+	//
+	// In one of the next steps we will use this to look up the actual data
+	// _and_ verify the generation of the reference.
+	meta := r.metadata()
+	meta.dataAddressAndGen = r.dataAddressAndGen
+
+	return r
 }
 
 //gcassert:noescape
@@ -84,10 +108,12 @@ func (r *RefPointer) AllocFromFree() (nextFree RefPointer) {
 		nextFree = RefPointer{}
 	}
 
-	// Increment the generation for the object and set that generation in
-	// the Reference
-	meta.gen++
-	r.setGen(meta.gen)
+	// Increment the generation for the allocation and set that generation in
+	// the Metadata and Reference
+	gen := meta.gen()
+	gen++
+	meta.setGen(gen)
+	r.setGen(gen)
 
 	return nextFree
 }
@@ -102,9 +128,7 @@ func (r *RefPointer) Free(oldFree RefPointer) {
 		panic(fmt.Errorf("attempted to Free freed allocation %v", *r))
 	}
 
-	if meta.gen != r.Gen() {
-		panic(fmt.Errorf("attempt to free allocation (%d) using stale reference (%d)", meta.gen, r.Gen()))
-	}
+	meta.checkReference(r)
 
 	if oldFree.IsNil() {
 		meta.nextFree = *r
@@ -130,12 +154,11 @@ func (r *RefPointer) DataPtr() uintptr {
 		// call, but if we don't take a copy of r in the fmt call, then
 		// every call will allocate regardless of whether the method
 		// panics or not
-		panic(fmt.Errorf("attempted to get freed allocation %v", *r))
+		panic(fmt.Errorf("attempt to get freed allocation %v", *r))
 	}
 
-	if meta.gen != r.Gen() {
-		panic(fmt.Errorf("attempt to get value (%d) using stale reference (%d)", meta.gen, r.Gen()))
-	}
+	meta.checkReference(r)
+
 	return (uintptr)(r.dataAddressAndGen & pointerMask)
 }
 
@@ -172,8 +195,14 @@ func (r *RefPointer) setGen(gen uint8) {
 // valid reference to the same location.
 func (r *RefPointer) Realloc() RefPointer {
 	newRef := *r
+
+	// Get metadata generation tag and increment it
 	meta := r.metadata()
-	meta.gen++
-	newRef.setGen(meta.gen)
+	gen := meta.gen()
+	gen++
+
+	// Set the new generation tag in both the metadata and reference
+	meta.setGen(gen)
+	newRef.setGen(gen)
 	return newRef
 }

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -58,21 +58,6 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 }
 
 //gcassert:noescape
-func (r *RefPointer) allocFromFree() {
-	meta := r.metadata()
-
-	// This object is now allocated and is no long free
-	meta.isFree = false
-
-	// Increment the generation for the allocation and set that generation in
-	// the Metadata and Reference
-	gen := meta.gen()
-	gen++
-	meta.setGen(gen)
-	r.setGen(gen)
-}
-
-//gcassert:noescape
 func (r *RefPointer) free() {
 	meta := r.metadata()
 
@@ -86,6 +71,42 @@ func (r *RefPointer) free() {
 
 	// Mark the object as free
 	meta.isFree = true
+
+	// Increment the generation for the allocation and set that generation in
+	// the Metadata and Reference
+	gen := meta.gen()
+	gen++
+	meta.setGen(gen)
+}
+
+// NB: In the future this method should return a new RefPointer with updated
+// generation tag instead of modifying the method receiver.
+//
+//gcassert:noescape
+func (r *RefPointer) allocFromFree() {
+	meta := r.metadata()
+
+	// This object is now allocated and is no long free
+	meta.isFree = false
+	// Update this reference so it's generatation tag matches the metadata
+	r.setGen(meta.gen())
+}
+
+// This method re-allocates the memory location. When this method returns r
+// will no longer be a valid reference.  The reference returned _will_ be a
+// valid reference to the same location.
+func (r *RefPointer) Realloc() RefPointer {
+	newRef := *r
+
+	// Get metadata generation tag and increment it
+	meta := r.metadata()
+	gen := meta.gen()
+	gen++
+
+	// Set the new generation tag in both the metadata and reference
+	meta.setGen(gen)
+	newRef.setGen(gen)
+	return newRef
 }
 
 //gcassert:noescape
@@ -138,21 +159,4 @@ func (r *RefPointer) Gen() uint8 {
 //gcassert:noescape
 func (r *RefPointer) setGen(gen uint8) {
 	r.dataAddressAndGen = r.dataAddressAndGen.withGen(gen)
-}
-
-// This method re-allocates the memory location. When this method returns r
-// will no longer be a valid reference.  The reference returned _will_ be a
-// valid reference to the same location.
-func (r *RefPointer) Realloc() RefPointer {
-	newRef := *r
-
-	// Get metadata generation tag and increment it
-	meta := r.metadata()
-	gen := meta.gen()
-	gen++
-
-	// Set the new generation tag in both the metadata and reference
-	meta.setGen(gen)
-	newRef.setGen(gen)
-	return newRef
 }

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -31,8 +31,8 @@ const pointerMask = ^genMask
 // is a meaningful improvement are speculative and haven't been tested. This
 // would be a good target for future performance testing.
 type RefPointer struct {
-	dataAddress uint64
-	metaAddress uint64
+	dataAddressAndGen uint64
+	metaAddress       uint64
 }
 
 // If the object's metadata has a non-nil nextFree pointer then the object is
@@ -66,8 +66,8 @@ func NewReference(pAddress, pMetadata uintptr) RefPointer {
 	// NB: The gen on a brand new Reference is always 0
 	// So we don't set it
 	return RefPointer{
-		dataAddress: maskedAddress,
-		metaAddress: uint64(pMetadata),
+		dataAddressAndGen: maskedAddress,
+		metaAddress:       uint64(pMetadata),
 	}
 }
 
@@ -136,7 +136,7 @@ func (r *RefPointer) DataPtr() uintptr {
 	if meta.gen != r.Gen() {
 		panic(fmt.Errorf("attempt to get value (%d) using stale reference (%d)", meta.gen, r.Gen()))
 	}
-	return (uintptr)(r.dataAddress & pointerMask)
+	return (uintptr)(r.dataAddressAndGen & pointerMask)
 }
 
 // Convenient method to retrieve raw data of an allocation
@@ -159,12 +159,12 @@ func (r *RefPointer) metadata() *metadata {
 
 //gcassert:noescape
 func (r *RefPointer) Gen() uint8 {
-	return (uint8)((r.dataAddress & genMask) >> maskShift)
+	return (uint8)((r.dataAddressAndGen & genMask) >> maskShift)
 }
 
 //gcassert:noescape
 func (r *RefPointer) setGen(gen uint8) {
-	r.dataAddress = (r.dataAddress & pointerMask) | (uint64(gen) << maskShift)
+	r.dataAddressAndGen = (r.dataAddressAndGen & pointerMask) | (uint64(gen) << maskShift)
 }
 
 // This method re-allocates the memory location. When this method returns r

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -33,9 +33,6 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 	}
 
 	// Set the dataAddressAndGen in this reference's metadata.
-	//
-	// In one of the next steps we will use this to look up the actual data
-	// _and_ verify the generation of the reference.
 	meta := r.metadata()
 	meta.dataAddressAndGen = newTaggedAddress(dataAddress)
 	// The value defaults to false, but we write it here for readability
@@ -53,11 +50,8 @@ func (r RefPointer) free() {
 	// Mark the object as free
 	meta.setFree()
 
-	// Increment the generation for the allocation and set that generation in
-	// the Metadata and Reference
-	gen := meta.gen()
-	gen++
-	meta.setGen(gen)
+	// Increment the generation for the allocation's metadata
+	meta.incGen()
 }
 
 // Sets the RefPointer's metadata to not-free and creates a new RefPointer with
@@ -72,8 +66,11 @@ func (r RefPointer) allocFromFree() RefPointer {
 	// This object is now allocated and is no long free
 	meta.setNotFree()
 
+	// Get the metadata generation tag
+	gen := meta.gen()
+
 	// Create new RefPointer with correct generation tag
-	return r.withGen(meta.gen())
+	return r.withGen(gen)
 }
 
 // This method re-allocates the memory location. When this method returns r
@@ -83,13 +80,12 @@ func (r RefPointer) Realloc() RefPointer {
 	// Test that this reference is actually allowed to access the allocation
 	r.accessibleActiveAddress()
 
-	// Get metadata generation tag and increment it
 	meta := r.metadata()
-	gen := meta.gen()
-	gen++
 
-	// Set the new generation tag in both the metadata and reference
-	meta.setGen(gen)
+	// Get and increment the metadata generation tag
+	gen := meta.incGen()
+
+	// Set the new generation tag in the reference
 	return r.withGen(gen)
 }
 

--- a/offheap/internal/pointerstore/pointer_reference.go
+++ b/offheap/internal/pointerstore/pointer_reference.go
@@ -76,6 +76,10 @@ func NewReference(dataAddress, metaAddress uintptr) RefPointer {
 		panic("cannot create new Reference with nil data pointer")
 	}
 
+	if metaAddress == (uintptr)(unsafe.Pointer(nil)) {
+		panic("cannot create new Reference with nil metadata pointer")
+	}
+
 	r := RefPointer{
 		dataAddressAndGen: uint64(dataAddress),
 		metaAddress:       uint64(metaAddress),

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -160,6 +160,15 @@ func TestAllocFromFree(t *testing.T) {
 	assert.NotPanics(t, func() { r.free() })
 }
 
+func TestAllocFromFree_NoFree(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 32*8)
+	objects, metadatas := MmapSlab(allocConfig)
+
+	r := NewReference(objects[0], metadatas[0])
+
+	assert.Panics(t, func() { r.allocFromFree() })
+}
+
 func TestRealloc(t *testing.T) {
 	allocConfig := NewAllocConfigBySize(8, 32*8)
 	objects, metadatas := MmapSlab(allocConfig)

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -122,6 +122,9 @@ func TestFree(t *testing.T) {
 	assert.Panics(t, func() { r.DataPtr() })
 	assert.Panics(t, func() { r.Bytes(8) })
 
+	// Reallocing a freed reference will panic
+	assert.Panics(t, func() { r.Realloc() })
+
 	// Freeing a freed reference will panic
 	assert.Panics(t, func() { r.free() })
 }

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -55,7 +55,7 @@ func TestNewReference(t *testing.T) {
 		// Bytes points to data at the correct location
 		assert.Equal(t, objects[i], uintptr(unsafe.Pointer(&r.Bytes(8)[0])))
 		// Metadata pointer points to the correct location
-		assert.Equal(t, metadata[i], r.metaAddress().address())
+		assert.Equal(t, metadata[i], r.address.address())
 		// Generation of a new Reference is always 0
 		assert.Equal(t, uint8(0), r.Gen())
 		// The data should be accessible through this reference

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -6,6 +6,7 @@ package pointerstore
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,9 +17,16 @@ func TestIsNil(t *testing.T) {
 	assert.True(t, r.IsNil())
 }
 
-// Calling newReference() with nil will panic
+// Calling newReference() with any nil uintptr parameter will panic
 func TestNewReferenceWithNilPanics(t *testing.T) {
-	assert.Panics(t, func() { NewReference(0, 0) })
+	nilPtr := uintptr(unsafe.Pointer(nil))
+
+	allocConfig := NewAllocConfigBySize(8, 8)
+	objects, metadata := MmapSlab(allocConfig)
+
+	assert.Panics(t, func() { NewReference(objects[0], nilPtr) })
+	assert.Panics(t, func() { NewReference(nilPtr, metadata[0]) })
+	assert.Panics(t, func() { NewReference(nilPtr, nilPtr) })
 }
 
 // Demonstrate that a pointer with any non-0 field is not nil

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -58,7 +58,7 @@ func TestNewReference(t *testing.T) {
 		assert.Equal(t, uint8(0), r.Gen())
 		// The dataAddressAndGen matches in both the reference and the metadata
 		meta := r.metadata()
-		assert.Equal(t, r.dataAddressAndGen, meta.dataAddressAndGen)
+		assert.Equal(t, r.address, meta.dataAddressAndGen)
 	}
 }
 
@@ -168,9 +168,9 @@ func TestRealloc(t *testing.T) {
 	meta2 := r2.metadata()
 
 	// The dataAddressAndGen matches in both the reference and the metadata
-	assert.Equal(t, r2.dataAddressAndGen, meta2.dataAddressAndGen)
+	assert.Equal(t, r2.address, meta2.dataAddressAndGen)
 	// The dataAddressAndGen of the original metadata has been updated to match r2
-	assert.Equal(t, r2.dataAddressAndGen, meta1.dataAddressAndGen)
+	assert.Equal(t, r2.address, meta1.dataAddressAndGen)
 
 	// Assert that the data/metadata pointed to by r1 and r2 is the same
 	assert.Equal(t, dataPtr, r2.DataPtr())

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -52,6 +52,8 @@ func TestNewReference(t *testing.T) {
 		assert.False(t, r.IsNil())
 		// Data pointer points to the correct location
 		assert.Equal(t, objects[i], r.DataPtr())
+		// Bytes points to data at the correct location
+		assert.Equal(t, objects[i], uintptr(unsafe.Pointer(&r.Bytes(8)[0])))
 		// Metadata pointer points to the correct location
 		assert.Equal(t, metadata[i], r.metadataPtr())
 		// Generation of a new Reference is always 0
@@ -118,6 +120,7 @@ func TestFree(t *testing.T) {
 
 	// Accessng the data of a freed reference will panic
 	assert.Panics(t, func() { r.DataPtr() })
+	assert.Panics(t, func() { r.Bytes(8) })
 
 	// Freeing a freed reference will panic
 	assert.Panics(t, func() { r.free() })
@@ -148,6 +151,7 @@ func TestAllocFromFree(t *testing.T) {
 
 	// Accessng the data of an allocated-from-free reference will not panic
 	assert.NotPanics(t, func() { r.DataPtr() })
+	assert.NotPanics(t, func() { r.Bytes(8) })
 
 	// Freeing an allocated-from-free reference will not panic
 	assert.NotPanics(t, func() { r.free() })
@@ -179,7 +183,11 @@ func TestRealloc(t *testing.T) {
 	// Assert that r2 has a different generation than r1
 	assert.NotEqual(t, gen, r2.Gen())
 
-	// Assert that r1 is no longer valid, but r2 is valid
+	// Assert that data is no longer accessible through r1
 	assert.Panics(t, func() { r1.DataPtr() })
+	assert.Panics(t, func() { r1.Bytes(8) })
+
+	// Assert that data is accessible through r2
 	assert.NotPanics(t, func() { r2.DataPtr() })
+	assert.NotPanics(t, func() { r2.Bytes(8) })
 }

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -86,12 +86,14 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 	dataPtr := r.DataPtr()
 	metadata := r.metadata()
 
-	metadata.setGen(maxGen)
-	r = r.withGen(maxGen)
+	for i := 1; i <= maxGen; i++ {
+		gen := metadata.incGen()
+		r = r.withGen(gen)
 
-	assert.Equal(t, dataPtr, r.DataPtr())
-	assert.Equal(t, metadata, r.metadata())
-	assert.Equal(t, uint8(maxGen), r.Gen())
+		assert.Equal(t, dataPtr, r.DataPtr())
+		assert.Equal(t, metadata, r.metadata())
+		assert.Equal(t, uint8(i%128), r.Gen())
+	}
 }
 
 func TestFree(t *testing.T) {

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -29,6 +29,19 @@ func TestNewReferenceWithNilPanics(t *testing.T) {
 	assert.Panics(t, func() { NewReference(nilPtr, nilPtr) })
 }
 
+// Calling newReference() with any uintptr parameter with generation tag bits set will panic
+func TestNewReferenceWithGenerationBitsSetPanics(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 8)
+	objects, metadata := MmapSlab(allocConfig)
+
+	badObject := objects[0] | (1 << maskShift)
+	badMeta := metadata[0] | (1 << maskShift)
+
+	assert.Panics(t, func() { NewReference(objects[0], badMeta) })
+	assert.Panics(t, func() { NewReference(badObject, metadata[0]) })
+	assert.Panics(t, func() { NewReference(badObject, badMeta) })
+}
+
 // Demonstrate that a pointer with any non-0 field is not nil
 func TestNewReference(t *testing.T) {
 	allocConfig := NewAllocConfigBySize(8, 32*8)

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -100,7 +100,7 @@ func TestFree(t *testing.T) {
 	r := NewReference(objects[0], metadatas[0])
 	meta := r.metadata()
 
-	assert.False(t, meta.isFree)
+	assert.False(t, meta.isFree())
 	assert.Equal(t, uint8(0), meta.dataAddressAndGen.gen())
 	assert.Equal(t, uint8(0), r.Gen())
 
@@ -110,7 +110,7 @@ func TestFree(t *testing.T) {
 	assert.Equal(t, meta, r.metadata())
 
 	// The metadata is now marked as free
-	assert.True(t, meta.isFree)
+	assert.True(t, meta.isFree())
 	// After free is called the metadata for this reference has a new
 	// generation tag, while the reference has the same old generation tag
 	assert.Equal(t, uint8(1), meta.dataAddressAndGen.gen())
@@ -130,7 +130,7 @@ func TestAllocFromFree(t *testing.T) {
 	r := NewReference(objects[0], metadatas[0])
 	meta := r.metadata()
 
-	assert.False(t, meta.isFree)
+	assert.False(t, meta.isFree())
 	assert.Equal(t, uint8(0), meta.dataAddressAndGen.gen())
 	assert.Equal(t, uint8(0), r.Gen())
 
@@ -141,7 +141,7 @@ func TestAllocFromFree(t *testing.T) {
 	assert.Equal(t, meta, r.metadata())
 
 	// The metadata is now marked as not free
-	assert.False(t, meta.isFree)
+	assert.False(t, meta.isFree())
 	// After allocFromFree is called the reference's generation will match the metadata's generation
 	assert.Equal(t, uint8(1), meta.dataAddressAndGen.gen())
 	assert.Equal(t, uint8(1), r.Gen())

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -85,13 +85,12 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 	metaPtr := r.metadataPtr()
 	metadata := r.metadata()
 
-	gen := uint8(255)
-	metadata.setGen(gen)
-	r.setGen(gen)
+	metadata.setGen(maxGen)
+	r.setGen(maxGen)
 
 	assert.Equal(t, dataPtr, r.DataPtr())
 	assert.Equal(t, metaPtr, r.metadataPtr())
-	assert.Equal(t, gen, r.Gen())
+	assert.Equal(t, uint8(maxGen), r.Gen())
 }
 
 func TestFree(t *testing.T) {

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -94,6 +94,66 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 	assert.Equal(t, gen, r.Gen())
 }
 
+func TestFree(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 32*8)
+	objects, metadatas := MmapSlab(allocConfig)
+
+	r := NewReference(objects[0], metadatas[0])
+	meta := r.metadata()
+
+	assert.False(t, meta.isFree)
+	assert.Equal(t, uint8(0), meta.dataAddressAndGen.gen())
+	assert.Equal(t, uint8(0), r.Gen())
+
+	r.free()
+
+	// The reference still points to the same metadata location
+	assert.Equal(t, meta, r.metadata())
+
+	// The metadata is now marked as free
+	assert.True(t, meta.isFree)
+	// After free is called the metadata for this reference has a new
+	// generation tag, while the reference has the same old generation tag
+	assert.Equal(t, uint8(1), meta.dataAddressAndGen.gen())
+	assert.Equal(t, uint8(0), r.Gen())
+
+	// Accessng the data of a freed reference will panic
+	assert.Panics(t, func() { r.DataPtr() })
+
+	// Freeing a freed reference will panic
+	assert.Panics(t, func() { r.free() })
+}
+
+func TestAllocFromFree(t *testing.T) {
+	allocConfig := NewAllocConfigBySize(8, 32*8)
+	objects, metadatas := MmapSlab(allocConfig)
+
+	r := NewReference(objects[0], metadatas[0])
+	meta := r.metadata()
+
+	assert.False(t, meta.isFree)
+	assert.Equal(t, uint8(0), meta.dataAddressAndGen.gen())
+	assert.Equal(t, uint8(0), r.Gen())
+
+	r.free()
+	r.allocFromFree()
+
+	// The reference still points to the same metadata location
+	assert.Equal(t, meta, r.metadata())
+
+	// The metadata is now marked as not free
+	assert.False(t, meta.isFree)
+	// After allocFromFree is called the reference's generation will match the metadata's generation
+	assert.Equal(t, uint8(1), meta.dataAddressAndGen.gen())
+	assert.Equal(t, uint8(1), r.Gen())
+
+	// Accessng the data of an allocated-from-free reference will not panic
+	assert.NotPanics(t, func() { r.DataPtr() })
+
+	// Freeing an allocated-from-free reference will not panic
+	assert.NotPanics(t, func() { r.free() })
+}
+
 func TestRealloc(t *testing.T) {
 	allocConfig := NewAllocConfigBySize(8, 32*8)
 	objects, metadatas := MmapSlab(allocConfig)

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -88,7 +88,7 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 	metadata := r.metadata()
 
 	metadata.setGen(maxGen)
-	r.setGen(maxGen)
+	r = r.withGen(maxGen)
 
 	assert.Equal(t, dataPtr, r.DataPtr())
 	assert.Equal(t, metaPtr, r.metaPtr())
@@ -141,7 +141,7 @@ func TestAllocFromFree(t *testing.T) {
 	assert.Equal(t, uint8(0), r.Gen())
 
 	r.free()
-	r.allocFromFree()
+	r = r.allocFromFree()
 
 	// The reference still points to the same metadata location
 	assert.Equal(t, meta, r.metadata())

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -84,14 +84,13 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 
 	r := NewReference(objects[0], metadatas[0])
 	dataPtr := r.DataPtr()
-	metaPtr := r.metaPtr()
 	metadata := r.metadata()
 
 	metadata.setGen(maxGen)
 	r = r.withGen(maxGen)
 
 	assert.Equal(t, dataPtr, r.DataPtr())
-	assert.Equal(t, metaPtr, r.metaPtr())
+	assert.Equal(t, metadata, r.metadata())
 	assert.Equal(t, uint8(maxGen), r.Gen())
 }
 
@@ -177,7 +176,7 @@ func TestRealloc(t *testing.T) {
 	meta1 := r1.metadata()
 
 	dataPtr := r1.DataPtr()
-	metaPtr := r1.metaPtr()
+	metadata := r1.metadata()
 	gen := r1.Gen()
 
 	r2 := r1.Realloc()
@@ -192,7 +191,7 @@ func TestRealloc(t *testing.T) {
 
 	// Assert that the data/metadata pointed to by r1 and r2 is the same
 	assert.Equal(t, dataPtr, r2.DataPtr())
-	assert.Equal(t, metaPtr, r2.metaPtr())
+	assert.Equal(t, metadata, r2.metadata())
 
 	// Assert that r2 has a different generation than r1
 	assert.NotEqual(t, gen, r2.Gen())

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -55,7 +55,7 @@ func TestNewReference(t *testing.T) {
 		// Bytes points to data at the correct location
 		assert.Equal(t, objects[i], uintptr(unsafe.Pointer(&r.Bytes(8)[0])))
 		// Metadata pointer points to the correct location
-		assert.Equal(t, metadata[i], r.address.address())
+		assert.Equal(t, metadata[i], r.address.pointer())
 		// Generation of a new Reference is always 0
 		assert.Equal(t, uint8(0), r.Gen())
 		// The data should be accessible through this reference

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -55,12 +55,12 @@ func TestNewReference(t *testing.T) {
 		// Bytes points to data at the correct location
 		assert.Equal(t, objects[i], uintptr(unsafe.Pointer(&r.Bytes(8)[0])))
 		// Metadata pointer points to the correct location
-		assert.Equal(t, metadata[i], r.metadataPtr())
+		assert.Equal(t, metadata[i], r.metaAddress().address())
 		// Generation of a new Reference is always 0
 		assert.Equal(t, uint8(0), r.Gen())
-		// The dataAddressAndGen matches in both the reference and the metadata
-		meta := r.metadata()
-		assert.Equal(t, r.address, meta.dataAddressAndGen)
+		// The data should be accessible through this reference
+		assert.NotPanics(t, func() { r.DataPtr() })
+		assert.NotPanics(t, func() { r.Bytes(8) })
 	}
 }
 
@@ -84,14 +84,14 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 
 	r := NewReference(objects[0], metadatas[0])
 	dataPtr := r.DataPtr()
-	metaPtr := r.metadataPtr()
+	metaPtr := r.metaPtr()
 	metadata := r.metadata()
 
 	metadata.setGen(maxGen)
 	r.setGen(maxGen)
 
 	assert.Equal(t, dataPtr, r.DataPtr())
-	assert.Equal(t, metaPtr, r.metadataPtr())
+	assert.Equal(t, metaPtr, r.metaPtr())
 	assert.Equal(t, uint8(maxGen), r.Gen())
 }
 
@@ -165,29 +165,31 @@ func TestRealloc(t *testing.T) {
 	meta1 := r1.metadata()
 
 	dataPtr := r1.DataPtr()
-	metaPtr := r1.metadataPtr()
+	metaPtr := r1.metaPtr()
 	gen := r1.Gen()
 
 	r2 := r1.Realloc()
 	meta2 := r2.metadata()
 
-	// The dataAddressAndGen matches in both the reference and the metadata
-	assert.Equal(t, r2.address, meta2.dataAddressAndGen)
-	// The dataAddressAndGen of the original metadata has been updated to match r2
-	assert.Equal(t, r2.address, meta1.dataAddressAndGen)
+	// The metadata of r1 and r2 is the same location
+	assert.Equal(t, meta1, meta2)
+	// The generation matches in both the r2 and the metadata
+	assert.Equal(t, r2.Gen(), meta2.gen())
+	// The generation does not match between r1 and the metadata
+	assert.NotEqual(t, r1.Gen(), meta2.gen())
 
 	// Assert that the data/metadata pointed to by r1 and r2 is the same
 	assert.Equal(t, dataPtr, r2.DataPtr())
-	assert.Equal(t, metaPtr, r2.metadataPtr())
+	assert.Equal(t, metaPtr, r2.metaPtr())
 
 	// Assert that r2 has a different generation than r1
 	assert.NotEqual(t, gen, r2.Gen())
 
-	// Assert that data is no longer accessible through r1
+	// Assert that data is no longer accessible via r1
 	assert.Panics(t, func() { r1.DataPtr() })
 	assert.Panics(t, func() { r1.Bytes(8) })
 
-	// Assert that data is accessible through r2
+	// Assert that data is accessible via r2
 	assert.NotPanics(t, func() { r2.DataPtr() })
 	assert.NotPanics(t, func() { r2.Bytes(8) })
 }

--- a/offheap/internal/pointerstore/pointer_reference_test.go
+++ b/offheap/internal/pointerstore/pointer_reference_test.go
@@ -22,7 +22,7 @@ func TestNewReferenceWithNilPanics(t *testing.T) {
 }
 
 // Demonstrate that a pointer with any non-0 field is not nil
-func TestIsNotNil(t *testing.T) {
+func TestNewReference(t *testing.T) {
 	allocConfig := NewAllocConfigBySize(8, 32*8)
 	objects, metadata := MmapSlab(allocConfig)
 	for i := range objects {
@@ -35,6 +35,9 @@ func TestIsNotNil(t *testing.T) {
 		assert.Equal(t, metadata[i], r.metadataPtr())
 		// Generation of a new Reference is always 0
 		assert.Equal(t, uint8(0), r.Gen())
+		// The dataAddressAndGen matches in both the reference and the metadata
+		meta := r.metadata()
+		assert.Equal(t, r.dataAddressAndGen, meta.dataAddressAndGen)
 	}
 }
 
@@ -62,7 +65,7 @@ func TestGenerationDoesNotAppearInOtherFields(t *testing.T) {
 	metadata := r.metadata()
 
 	gen := uint8(255)
-	metadata.gen = gen
+	metadata.setGen(gen)
 	r.setGen(gen)
 
 	assert.Equal(t, dataPtr, r.DataPtr())
@@ -75,11 +78,19 @@ func TestRealloc(t *testing.T) {
 	objects, metadatas := MmapSlab(allocConfig)
 
 	r1 := NewReference(objects[0], metadatas[0])
+	meta1 := r1.metadata()
+
 	dataPtr := r1.DataPtr()
 	metaPtr := r1.metadataPtr()
 	gen := r1.Gen()
 
 	r2 := r1.Realloc()
+	meta2 := r2.metadata()
+
+	// The dataAddressAndGen matches in both the reference and the metadata
+	assert.Equal(t, r2.dataAddressAndGen, meta2.dataAddressAndGen)
+	// The dataAddressAndGen of the original metadata has been updated to match r2
+	assert.Equal(t, r2.dataAddressAndGen, meta1.dataAddressAndGen)
 
 	// Assert that the data/metadata pointed to by r1 and r2 is the same
 	assert.Equal(t, dataPtr, r2.DataPtr())

--- a/offheap/internal/pointerstore/pointer_store.go
+++ b/offheap/internal/pointerstore/pointer_store.go
@@ -129,9 +129,8 @@ func (s *Store) allocFromFree() (RefPointer, bool) {
 		return RefPointer{}, false
 	}
 
-	// set up the reference to be 'allocated'
-	r.allocFromFree()
-	return r, true
+	// Create new allocated reference
+	return r.allocFromFree(), true
 }
 
 func (s *Store) allocFromOffset() RefPointer {

--- a/offheap/internal/pointerstore/pointer_store.go
+++ b/offheap/internal/pointerstore/pointer_store.go
@@ -32,7 +32,7 @@ type Store struct {
 
 	// freeRWLock protects rootFree
 	freeLock sync.Mutex
-	freeList []RefPointer
+	freeList freeStack
 
 	// objectsLock protects objects
 	// Allocating to an existing slab with a free slot only needs a read lock
@@ -69,7 +69,7 @@ func (s *Store) Free(r RefPointer) {
 
 	// Set up the reference to be 'free'
 	r.free()
-	s.freeList = append(s.freeList, r)
+	s.freeList.push(r)
 
 	s.frees.Add(1)
 }
@@ -124,19 +124,13 @@ func (s *Store) allocFromFree() (RefPointer, bool) {
 	s.freeLock.Lock()
 	defer s.freeLock.Unlock()
 
-	// No free objects available - allocFromFree failed
-	if len(s.freeList) == 0 {
+	r, ok := s.freeList.pop()
+	if !ok {
 		return RefPointer{}, false
 	}
 
-	// pop the most recently freed reference off the free list
-	// TODO might be worth writing a small stack for this
-	r := s.freeList[len(s.freeList)-1]
-	s.freeList = s.freeList[:len(s.freeList)-1]
-
 	// set up the reference to be 'allocated'
 	r.allocFromFree()
-
 	return r, true
 }
 

--- a/offheap/internal/pointerstore/pointer_store.go
+++ b/offheap/internal/pointerstore/pointer_store.go
@@ -32,7 +32,7 @@ type Store struct {
 
 	// freeRWLock protects rootFree
 	freeLock sync.Mutex
-	rootFree RefPointer
+	freeList []RefPointer
 
 	// objectsLock protects objects
 	// Allocating to an existing slab with a free slot only needs a read lock
@@ -67,8 +67,9 @@ func (s *Store) Free(r RefPointer) {
 	s.freeLock.Lock()
 	defer s.freeLock.Unlock()
 
-	r.Free(s.rootFree)
-	s.rootFree = r
+	// Set up the reference to be 'free'
+	r.free()
+	s.freeList = append(s.freeList, r)
 
 	s.frees.Add(1)
 }
@@ -124,15 +125,19 @@ func (s *Store) allocFromFree() (RefPointer, bool) {
 	defer s.freeLock.Unlock()
 
 	// No free objects available - allocFromFree failed
-	if s.rootFree.IsNil() {
+	if len(s.freeList) == 0 {
 		return RefPointer{}, false
 	}
 
-	// Get pointer to the next available freed slot
-	alloc := s.rootFree
-	s.rootFree = alloc.AllocFromFree()
+	// pop the most recently freed reference off the free list
+	// TODO might be worth writing a small stack for this
+	r := s.freeList[len(s.freeList)-1]
+	s.freeList = s.freeList[:len(s.freeList)-1]
 
-	return alloc, true
+	// set up the reference to be 'allocated'
+	r.allocFromFree()
+
+	return r, true
 }
 
 func (s *Store) allocFromOffset() RefPointer {

--- a/offheap/internal/pointerstore/pointer_store_test.go
+++ b/offheap/internal/pointerstore/pointer_store_test.go
@@ -73,7 +73,7 @@ func TestSlabIntegrity(t *testing.T) {
 				}
 
 				baseSlabData := refs[0].DataPtr()
-				baseSlabMetadata := refs[0].metadataPtr()
+				baseSlabMetadata := refs[0].metaPtr()
 
 				// Check that the metadata is allocated immediately _after_ the data
 				assert.Equal(t, baseSlabMetadata, baseSlabData+uintptr(conf.TotalObjectSize))
@@ -86,7 +86,7 @@ func TestSlabIntegrity(t *testing.T) {
 					assert.Equal(t, baseSlabData+expectedDataOffset, dataPtr)
 
 					// Check that the metadata allocations are spaced out appropriately
-					metaPtr := ref.metadataPtr()
+					metaPtr := ref.metaPtr()
 					expectedMetaOffset := uintptr(conf.MetadataSize) * uintptr(i)
 					assert.Equal(t, baseSlabMetadata+expectedMetaOffset, metaPtr)
 				}

--- a/offheap/internal/pointerstore/pointer_store_test.go
+++ b/offheap/internal/pointerstore/pointer_store_test.go
@@ -7,6 +7,7 @@ package pointerstore
 import (
 	"fmt"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -73,7 +74,7 @@ func TestSlabIntegrity(t *testing.T) {
 				}
 
 				baseSlabData := refs[0].DataPtr()
-				baseSlabMetadata := refs[0].metaPtr()
+				baseSlabMetadata := uintptr(unsafe.Pointer(refs[0].metadata()))
 
 				// Check that the metadata is allocated immediately _after_ the data
 				assert.Equal(t, baseSlabMetadata, baseSlabData+uintptr(conf.TotalObjectSize))
@@ -86,7 +87,7 @@ func TestSlabIntegrity(t *testing.T) {
 					assert.Equal(t, baseSlabData+expectedDataOffset, dataPtr)
 
 					// Check that the metadata allocations are spaced out appropriately
-					metaPtr := ref.metaPtr()
+					metaPtr := uintptr(unsafe.Pointer(ref.metadata()))
 					expectedMetaOffset := uintptr(conf.MetadataSize) * uintptr(i)
 					assert.Equal(t, baseSlabMetadata+expectedMetaOffset, metaPtr)
 				}

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -9,16 +9,28 @@ import (
 	"unsafe"
 )
 
-const nilPtr = uintptr(0)
-const maxGen = 0x7F
-const maskShift = 56                                // This leaves 8 bits for the generation and isFree tags
-const isFreeMask = taggedAddress(0x80 << maskShift) // Highest bit indicates if address is free
-const genMask = taggedAddress(maxGen << maskShift)  // Next 7 bits indicate generation tag
-const tagMask = isFreeMask | genMask                // Mask revealing all 8 tag bits
-const pointerMask = ^tagMask                        // Mask revealing 56 address bits
-
-const setFree = isFreeMask
-const setNotFree = ^setFree
+const (
+	// handy nil pointer constant
+	nilPtr = uintptr(0)
+	// maximum value of the generation tag (127)
+	maxGen = 0x7F
+	// This leaves 8 bits for the generation and isFree tags
+	maskShift = 56
+	// Highest bit indicates if address is free
+	isFreeMask = taggedAddress(0x80 << maskShift)
+	// Next 7 bits indicate generation tag
+	genMask = taggedAddress(maxGen << maskShift)
+	// Mask revealing all 8 tag bits
+	tagMask = isFreeMask | genMask
+	// Mask revealing 56 address bits
+	addressMask = ^tagMask
+	// Mask revealing address and is-free bit, allows us to safely set generation tag
+	addressAndIsFreeMask = addressMask | isFreeMask
+	// Mask which can be used to directly set the is-free bit to 1
+	setFree = isFreeMask
+	// Mask which can be used to directly set the is-free bit to 0
+	setNotFree = ^setFree
+)
 
 type taggedAddress uint64
 
@@ -35,7 +47,7 @@ func (a taggedAddress) gen() uint8 {
 }
 
 func (a taggedAddress) address() uintptr {
-	return uintptr(a & pointerMask)
+	return uintptr(a & addressMask)
 }
 
 func (a taggedAddress) bytes(size int) []byte {
@@ -51,7 +63,7 @@ func (a taggedAddress) isNil() bool {
 }
 
 func (a taggedAddress) withGen(gen uint8) taggedAddress {
-	return (a & (pointerMask | isFreeMask)) | (taggedAddress(gen) << maskShift)
+	return (a & (addressAndIsFreeMask)) | (taggedAddress(gen) << maskShift)
 }
 
 func (a taggedAddress) withFree() taggedAddress {

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -46,12 +46,12 @@ func (a taggedAddress) gen() uint8 {
 	return (uint8)((a & genMask) >> maskShift)
 }
 
-func (a taggedAddress) address() uintptr {
+func (a taggedAddress) pointer() uintptr {
 	return uintptr(a & addressMask)
 }
 
 func (a taggedAddress) bytes(size int) []byte {
-	return ([]byte)(unsafe.Slice((*byte)((unsafe.Pointer)(a.address())), size))
+	return ([]byte)(unsafe.Slice((*byte)((unsafe.Pointer)(a.pointer())), size))
 }
 
 func (a taggedAddress) isFree() bool {
@@ -59,7 +59,7 @@ func (a taggedAddress) isFree() bool {
 }
 
 func (a taggedAddress) isNil() bool {
-	return a.address() == nilPtr
+	return a.pointer() == nilPtr
 }
 
 func (a taggedAddress) withGen(gen uint8) taggedAddress {

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -11,14 +11,13 @@ import (
 
 const nilPtr = uintptr(0)
 const maxGen = 0x7F
-
 const maskShift = 56                                // This leaves 8 bits for the generation and isFree tags
 const isFreeMask = taggedAddress(0x80 << maskShift) // Highest bit indicates if address is free
-const genMask = taggedAddress(0x7F << maskShift)    // Next 7 bits indicate generation tag
-const tagMask = isFreeMask | genMask
-const pointerMask = ^tagMask
+const genMask = taggedAddress(maxGen << maskShift)  // Next 7 bits indicate generation tag
+const tagMask = isFreeMask | genMask                // Mask revealing all 8 tag bits
+const pointerMask = ^tagMask                        // Mask revealing 56 address bits
 
-const setFree = taggedAddress(0x80 << maskShift)
+const setFree = isFreeMask
 const setNotFree = ^setFree
 
 type taggedAddress uint64
@@ -52,7 +51,7 @@ func (a taggedAddress) isNil() bool {
 }
 
 func (a taggedAddress) withGen(gen uint8) taggedAddress {
-	return (a & pointerMask) | (taggedAddress(gen) << maskShift)
+	return (a & (pointerMask | isFreeMask)) | (taggedAddress(gen) << maskShift)
 }
 
 func (a taggedAddress) withFree() taggedAddress {

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -9,9 +9,17 @@ import (
 	"unsafe"
 )
 
-const maskShift = 56 // This leaves 8 bits for the generation data
-const genMask = taggedAddress(0xFF << maskShift)
-const pointerMask = ^genMask
+const nilPtr = uintptr(0)
+const maxGen = 0x7F
+
+const maskShift = 56                                // This leaves 8 bits for the generation and isFree tags
+const isFreeMask = taggedAddress(0x80 << maskShift) // Highest bit indicates if address is free
+const genMask = taggedAddress(0x7F << maskShift)    // Next 7 bits indicate generation tag
+const tagMask = isFreeMask | genMask
+const pointerMask = ^tagMask
+
+const setFree = taggedAddress(0x80 << maskShift)
+const setNotFree = ^setFree
 
 type taggedAddress uint64
 
@@ -31,14 +39,26 @@ func (a taggedAddress) address() uintptr {
 	return uintptr(a & pointerMask)
 }
 
-func (a taggedAddress) withGen(gen uint8) taggedAddress {
-	return (a & pointerMask) | (taggedAddress(gen) << maskShift)
-}
-
 func (a taggedAddress) bytes(size int) []byte {
 	return ([]byte)(unsafe.Slice((*byte)((unsafe.Pointer)(a.address())), size))
 }
 
+func (a taggedAddress) isFree() bool {
+	return a&setFree == setFree
+}
+
 func (a taggedAddress) isNil() bool {
-	return a.address() == 0
+	return a.address() == nilPtr
+}
+
+func (a taggedAddress) withGen(gen uint8) taggedAddress {
+	return (a & pointerMask) | (taggedAddress(gen) << maskShift)
+}
+
+func (a taggedAddress) withFree() taggedAddress {
+	return a | setFree
+}
+
+func (a taggedAddress) withNotFree() taggedAddress {
+	return a & setNotFree
 }

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -37,7 +37,7 @@ type taggedAddress uint64
 func newTaggedAddress(ptr uintptr) taggedAddress {
 	ta := taggedAddress(ptr)
 	if ta.gen() != 0 {
-		panic(fmt.Errorf("Cannot create tagged address from pointer (%d) with bits set in the generation tag (%d).", ptr, ta.gen()))
+		panic(fmt.Errorf("cannot create tagged address from pointer (%d) with bits set in the generation tag (%d)", ptr, ta.gen()))
 	}
 	return ta
 }

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -20,6 +20,9 @@ const (
 	isFreeMask = taggedAddress(0x80 << maskShift)
 	// Next 7 bits indicate generation tag
 	genMask = taggedAddress(maxGen << maskShift)
+	// A generation value of one. This is used to increment generation
+	// values
+	genOne = taggedAddress(1 << maskShift)
 	// Mask revealing all 8 tag bits
 	tagMask = isFreeMask | genMask
 	// Mask revealing 56 address bits
@@ -63,7 +66,17 @@ func (a taggedAddress) isNil() bool {
 }
 
 func (a taggedAddress) withGen(gen uint8) taggedAddress {
-	return (a & (addressAndIsFreeMask)) | (taggedAddress(gen) << maskShift)
+	// move the new gen into postion
+	newGen := (taggedAddress(gen) << maskShift) & genMask
+	// Set the new generation value back into the address
+	return (a & addressAndIsFreeMask) | newGen
+}
+
+func (a taggedAddress) withIncGen() taggedAddress {
+	// increment the generation value alone
+	newGen := (a + genOne) & genMask
+	// Set the new generation value back into the address
+	return (a & addressAndIsFreeMask) | newGen
 }
 
 func (a taggedAddress) withFree() taggedAddress {

--- a/offheap/internal/pointerstore/tagged_address.go
+++ b/offheap/internal/pointerstore/tagged_address.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Francis Michael Stephens. All rights reserved.  Use of this
+// source code is governed by an MIT license that can be found in the LICENSE
+// file.
+
+package pointerstore
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+const maskShift = 56 // This leaves 8 bits for the generation data
+const genMask = taggedAddress(0xFF << maskShift)
+const pointerMask = ^genMask
+
+type taggedAddress uint64
+
+func newTaggedAddress(ptr uintptr) taggedAddress {
+	ta := taggedAddress(ptr)
+	if ta.gen() != 0 {
+		panic(fmt.Errorf("Cannot create tagged address from pointer (%d) with bits set in the generation tag (%d).", ptr, ta.gen()))
+	}
+	return ta
+}
+
+func (a taggedAddress) gen() uint8 {
+	return (uint8)((a & genMask) >> maskShift)
+}
+
+func (a taggedAddress) address() uintptr {
+	return uintptr(a & pointerMask)
+}
+
+func (a taggedAddress) withGen(gen uint8) taggedAddress {
+	return (a & pointerMask) | (taggedAddress(gen) << maskShift)
+}
+
+func (a taggedAddress) bytes(size int) []byte {
+	return ([]byte)(unsafe.Slice((*byte)((unsafe.Pointer)(a.address())), size))
+}
+
+func (a taggedAddress) isNil() bool {
+	return a.address() == 0
+}

--- a/offheap/internal/pointerstore/tagged_address_test.go
+++ b/offheap/internal/pointerstore/tagged_address_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Francis Michael Stephens. All rights reserved.  Use of this
+// source code is governed by an MIT license that can be found in the LICENSE
+// file.
+
+package pointerstore
+
+import (
+	"math/rand"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const addressShift = 64 - maskShift
+const maxAddress = (1 << addressShift) - 1
+
+// For a nil uintptr the address and generation tag are zero
+func TestTaggedAddress_ZeroValue(t *testing.T) {
+	var ta taggedAddress
+
+	// address and gen are 0
+	assert.True(t, ta.isNil())
+	assert.Equal(t, uintptr(unsafe.Pointer(nil)), ta.address())
+	assert.Equal(t, uint8(0), ta.gen())
+}
+
+// For a nil uintptr the address and generation tag are zero
+func TestTaggedAddress_NewTaggedAddress_Zero(t *testing.T) {
+	nilPtr := uintptr(unsafe.Pointer(nil))
+	ta := newTaggedAddress(nilPtr)
+
+	// address and gen are 0
+	assert.True(t, ta.isNil())
+	assert.Equal(t, nilPtr, ta.address())
+	assert.Equal(t, uint8(0), ta.gen())
+}
+
+// For any legal address and generation tag combination the address and
+// generation tag are available unaltered
+func TestTaggedAddress_AddressAndGenAreSeparate(t *testing.T) {
+	for range 10 {
+		newPtr := uintptr(rand.Int63n(maxAddress + 1))
+		ta := newTaggedAddress(newPtr)
+
+		for i := 1; i <= 255; i++ {
+			gen := uint8(i)
+			// set tagged address generation
+			ta = ta.withGen(gen)
+
+			// If the address is not 0 then isNil() must be false
+			assert.Equal(t, newPtr == 0, ta.isNil())
+			// Assert that the original address is preserved
+			assert.Equal(t, newPtr, ta.address())
+			// Assert that the generation is preserved
+			assert.Equal(t, gen, ta.gen())
+		}
+	}
+}
+
+// For any address with bits set in the generation tag region (i.e. upper 8
+// bits) newTaggedAddress() panics
+func TestTaggedAddress_PointerWithGenBitsPanics(t *testing.T) {
+	for range 10 {
+		newPtr := uintptr(rand.Int63n(maxAddress + 1))
+
+		//for genBits := uintptr(1); genBits <= uintptr(255); genBits++ {
+		for i := 1; i <= 255; i++ {
+			genBits := uintptr(i)
+			// Create a pointer with bits set in the gen tag bits
+			badPtr := newPtr | ((genBits) << maskShift)
+			assert.Panics(t, func() { newTaggedAddress(badPtr) })
+		}
+	}
+}

--- a/offheap/internal/pointerstore/tagged_address_test.go
+++ b/offheap/internal/pointerstore/tagged_address_test.go
@@ -20,7 +20,7 @@ func TestTaggedAddress_ZeroValue(t *testing.T) {
 
 	// address and gen are 0
 	assert.True(t, ta.isNil())
-	assert.Equal(t, uintptr(unsafe.Pointer(nil)), ta.address())
+	assert.Equal(t, uintptr(unsafe.Pointer(nil)), ta.pointer())
 	assert.Equal(t, uint8(0), ta.gen())
 }
 
@@ -31,7 +31,7 @@ func TestTaggedAddress_NewTaggedAddress_Zero(t *testing.T) {
 
 	// address and gen are 0
 	assert.True(t, ta.isNil())
-	assert.Equal(t, nilPtr, ta.address())
+	assert.Equal(t, nilPtr, ta.pointer())
 	assert.Equal(t, uint8(0), ta.gen())
 }
 
@@ -50,7 +50,7 @@ func TestTaggedAddress_AddressAndGenAreSeparate(t *testing.T) {
 			// If the address is not 0 then isNil() must be false
 			assert.Equal(t, newPtr == nilPtr, ta.isNil())
 			// Assert that the original address is preserved
-			assert.Equal(t, newPtr, ta.address())
+			assert.Equal(t, newPtr, ta.pointer())
 			// Assert that the generation is preserved
 			assert.Equal(t, gen, ta.gen())
 		}
@@ -77,19 +77,19 @@ func TestTaggedAddress_IsFree(t *testing.T) {
 		newPtr := uintptr(rand.Int63n(maxAddress + 1))
 
 		ta := newTaggedAddress(newPtr)
-		address := ta.address()
+		address := ta.pointer()
 		gen := ta.gen()
 		// A tagged address is created not-free. It is assumed that a
 		// tagged address is only created for an allocation
 		assert.False(t, ta.isFree())
 		// Neither the address nor the generation tag are changed by the is-free bit
-		assert.Equal(t, address, ta.address())
+		assert.Equal(t, address, ta.pointer())
 		assert.Equal(t, gen, ta.gen())
 
 		ta = ta.withFree()
 		assert.True(t, ta.isFree())
 		// Neither the address nor the generation tag are changed by the is-free bit
-		assert.Equal(t, address, ta.address())
+		assert.Equal(t, address, ta.pointer())
 		assert.Equal(t, gen, ta.gen())
 
 		// Side-quest, set the generation tag and ensure this doesn't
@@ -97,7 +97,7 @@ func TestTaggedAddress_IsFree(t *testing.T) {
 		ta = ta.withGen(maxGen)
 		assert.True(t, ta.isFree())
 		// Neither the address nor the generation tag are changed by the is-free bit
-		assert.Equal(t, address, ta.address())
+		assert.Equal(t, address, ta.pointer())
 		assert.Equal(t, uint8(maxGen), ta.gen())
 
 		// Set the generation back
@@ -106,7 +106,7 @@ func TestTaggedAddress_IsFree(t *testing.T) {
 		ta = ta.withNotFree()
 		assert.False(t, ta.isFree())
 		// Neither the address nor the generation tag are changed by the is-free bit
-		assert.Equal(t, address, ta.address())
+		assert.Equal(t, address, ta.pointer())
 		assert.Equal(t, gen, ta.gen())
 	}
 }

--- a/offheap/internal/pointerstore/tagged_address_test.go
+++ b/offheap/internal/pointerstore/tagged_address_test.go
@@ -57,6 +57,64 @@ func TestTaggedAddress_AddressAndGenAreSeparate(t *testing.T) {
 	}
 }
 
+// For any legal address and generation tag combination the address and
+// generation tag are available unaltered
+func TestTaggedAddress_WithGen(t *testing.T) {
+	for range 10 {
+		newPtr := uintptr(rand.Int63n(maxAddress + 1))
+		ta := newTaggedAddress(newPtr)
+		testWithGen(t, ta.withNotFree())
+		testWithGen(t, ta.withFree())
+	}
+}
+
+func testWithGen(t *testing.T, ta taggedAddress) {
+	ptr := ta.pointer()
+	isFree := ta.isFree()
+	for i := 0; i <= maxGen*4; i++ {
+		// increment tagged address generation
+		ta = ta.withGen(uint8(i))
+
+		// If the address is not 0 then isNil() must be false
+		assert.Equal(t, ptr == nilPtr, ta.isNil())
+		// Assert that the original address is preserved
+		assert.Equal(t, ptr, ta.pointer())
+		// Assert if the address remains free or not free
+		assert.Equal(t, isFree, ta.isFree())
+		// Assert that the generation is preserved
+		assert.Equal(t, uint8(i%128), ta.gen())
+	}
+}
+
+// For any legal address and generation tag combination the address and
+// generation tag are available unaltered
+func TestTaggedAddress_IncGen(t *testing.T) {
+	for range 10 {
+		newPtr := uintptr(rand.Int63n(maxAddress + 1))
+		ta := newTaggedAddress(newPtr)
+		testIncGen(t, ta.withNotFree())
+		testIncGen(t, ta.withFree())
+	}
+}
+
+func testIncGen(t *testing.T, ta taggedAddress) {
+	ptr := ta.pointer()
+	isFree := ta.isFree()
+	for i := 0; i <= maxGen*4; i++ {
+		// If the address is not 0 then isNil() must be false
+		assert.Equal(t, ptr == nilPtr, ta.isNil())
+		// Assert that the original address is preserved
+		assert.Equal(t, ptr, ta.pointer())
+		// Assert if the address remains free or not free
+		assert.Equal(t, isFree, ta.isFree())
+		// Assert that the generation is preserved
+		assert.Equal(t, uint8(i%128), ta.gen())
+
+		// increment tagged address generation
+		ta = ta.withIncGen()
+	}
+}
+
 // For any address with bits set in the generation tag region (i.e. upper 8
 // bits) newTaggedAddress() panics
 func TestTaggedAddress_PointerWithGenBitsPanics(t *testing.T) {

--- a/offheap/internal/pointerstore/tagged_address_test.go
+++ b/offheap/internal/pointerstore/tagged_address_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const addressShift = 64 - maskShift
-const maxAddress = (1 << addressShift) - 1
+const maxAddress = (1 << (64 - maskShift)) - 1
 
 // For a nil uintptr the address and generation tag are zero
 func TestTaggedAddress_ZeroValue(t *testing.T) {
@@ -43,13 +42,13 @@ func TestTaggedAddress_AddressAndGenAreSeparate(t *testing.T) {
 		newPtr := uintptr(rand.Int63n(maxAddress + 1))
 		ta := newTaggedAddress(newPtr)
 
-		for i := 1; i <= 255; i++ {
+		for i := 1; i <= maxGen; i++ {
 			gen := uint8(i)
 			// set tagged address generation
 			ta = ta.withGen(gen)
 
 			// If the address is not 0 then isNil() must be false
-			assert.Equal(t, newPtr == 0, ta.isNil())
+			assert.Equal(t, newPtr == nilPtr, ta.isNil())
 			// Assert that the original address is preserved
 			assert.Equal(t, newPtr, ta.address())
 			// Assert that the generation is preserved
@@ -64,12 +63,39 @@ func TestTaggedAddress_PointerWithGenBitsPanics(t *testing.T) {
 	for range 10 {
 		newPtr := uintptr(rand.Int63n(maxAddress + 1))
 
-		//for genBits := uintptr(1); genBits <= uintptr(255); genBits++ {
-		for i := 1; i <= 255; i++ {
+		for i := 1; i <= maxGen; i++ {
 			genBits := uintptr(i)
 			// Create a pointer with bits set in the gen tag bits
 			badPtr := newPtr | ((genBits) << maskShift)
 			assert.Panics(t, func() { newTaggedAddress(badPtr) })
 		}
+	}
+}
+
+func TestTaggedAddress_IsFree(t *testing.T) {
+	for range 10 {
+		newPtr := uintptr(rand.Int63n(maxAddress + 1))
+
+		ta := newTaggedAddress(newPtr)
+		address := ta.address()
+		gen := ta.gen()
+		// A tagged address is created not-free. It is assumed that a
+		// tagged address is only created for an allocation
+		assert.False(t, ta.isFree())
+		// Neither the address nor the generation tag are changed by the is-free bit
+		assert.Equal(t, address, ta.address())
+		assert.Equal(t, gen, ta.gen())
+
+		ta = ta.withFree()
+		assert.True(t, ta.isFree())
+		// Neither the address nor the generation tag are changed by the is-free bit
+		assert.Equal(t, address, ta.address())
+		assert.Equal(t, gen, ta.gen())
+
+		ta = ta.withNotFree()
+		assert.False(t, ta.isFree())
+		// Neither the address nor the generation tag are changed by the is-free bit
+		assert.Equal(t, address, ta.address())
+		assert.Equal(t, gen, ta.gen())
 	}
 }

--- a/offheap/internal/pointerstore/tagged_address_test.go
+++ b/offheap/internal/pointerstore/tagged_address_test.go
@@ -92,6 +92,17 @@ func TestTaggedAddress_IsFree(t *testing.T) {
 		assert.Equal(t, address, ta.address())
 		assert.Equal(t, gen, ta.gen())
 
+		// Side-quest, set the generation tag and ensure this doesn't
+		// interfere with the is-free bit
+		ta = ta.withGen(maxGen)
+		assert.True(t, ta.isFree())
+		// Neither the address nor the generation tag are changed by the is-free bit
+		assert.Equal(t, address, ta.address())
+		assert.Equal(t, uint8(maxGen), ta.gen())
+
+		// Set the generation back
+		ta = ta.withGen(gen)
+
 		ta = ta.withNotFree()
 		assert.False(t, ta.isFree())
 		// Neither the address nor the generation tag are changed by the is-free bit

--- a/offheap/object_bench_test.go
+++ b/offheap/object_bench_test.go
@@ -1,0 +1,33 @@
+package offheap
+
+import "testing"
+
+type benchStruct struct {
+	field int
+}
+
+func BenchmarkAllocWriteRead(b *testing.B) {
+	os := New()
+
+	refs := make([]RefObject[benchStruct], 0, b.N)
+
+	for range b.N {
+		ref := AllocObject[benchStruct](os)
+		refs = append(refs, ref)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := range b.N {
+		refs[i].Value().field = i
+	}
+
+	sum := 0
+
+	for i := range b.N {
+		sum += refs[i].Value().field
+	}
+
+	println(sum)
+}

--- a/offheap/object_reference_test.go
+++ b/offheap/object_reference_test.go
@@ -345,10 +345,10 @@ func Test_Object_CannotAllocateVeryBigStruct(t *testing.T) {
 //
 // This test should alert us if this problem ever reappears.
 //
-// NB: In the future meta-data will likely be moved to a separate allocation
-// space and some details described above will become out of date. The test
-// will still be useful though. Zero sized types are a likely source of
-// edge-case bugs for all eternity.
+// NB: At time of update meta-data has been moved to a separate allocation
+// space and some details described above are out of date. The test is still
+// useful though. Zero sized types are a likely source of edge-case bugs for
+// all eternity.
 func Test_Object_ZeroSizedType_FullSlab(t *testing.T) {
 	os := New()
 	defer func() {


### PR DESCRIPTION
We achieve this by removing the pair of addresses in RefPointer which point

```
           | dataAddress  -> []byte
RefPointer |
           | metaAddress -> metadata
```

Instead we arrange our addresses in a chain

```
RefPointer | metaAddress -> metadata | dataAddress -> []byte
```

We can still verify the generation in the RefPointer matches that in the metadata.

Shrinking the RefPointer down a single word allows us to perform the usual atomic actions, such as CAS etc. The complexity of attempting to support this with two words was too complex to really consider.

A potential future benefit would be to allow us to have a const flag which when enabled (using a compiler option to set a constant value) we can disable the metadata check completely and allow faster direct memory reads.

